### PR TITLE
Enabled Docker for remote hosts

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,21 @@
+FROM alpine:3.15.0 as alpine_builder
+
+RUN apk add --no-cache openssl-dev git curl build-base rustup musl perl
+
+WORKDIR /code/oura
+RUN git config --global init.defaultBranch main &&  \
+    git config --global advice.detachedHead false
+
+RUN gitrev=v0.3.0 && \
+    git init && \
+    git remote add origin https://github.com/txpipe/oura.git && \
+    git fetch --depth 1 origin tag "$gitrev" && \
+    git checkout "$gitrev"
+
+RUN rustup-init -y
+RUN source $HOME/.cargo/env
+RUN $HOME/.cargo/bin/cargo build --release --locked --target x86_64-unknown-linux-musl
+
+FROM alpine:3.15.0
+COPY --from=alpine_builder /code/oura/target/x86_64-unknown-linux-musl/release/oura .
+ENTRYPOINT ["./oura"]

--- a/docker/docker.md
+++ b/docker/docker.md
@@ -1,0 +1,31 @@
+# Docker Instructions
+
+## Before start
+
+Must have Docker container system already installed on your machine. For more information refer to [this](https://www.docker.com/) link.
+
+Docker oura version (at least for now) works **only** for tcp bearers or also known as "remote nodes"
+
+## Usage
+### Build
+
+To build oura on your station simply execute the following command and Docker shall create the image:
+
+```sh
+sudo docker build -t oura:latest . 
+```
+
+As a sidenote, the **Dockerfile** performs two different steps:
+
+* Builds the image binary
+* Execute the `oura` app
+
+### Run
+
+The following command will start the oura tail app and see live data. The oura commands are provided on the entrypoint, so you only need to provide the arguments. 
+
+For instance, on this example I'm getting the events from `relays-new.cardano-mainnet.iohk.io` on mainnet:
+
+```sh
+sudo docker run -t --name oura oura:latest watch relays-new.cardano-mainnet.iohk.io:3001 --bearer tcp --magic mainnet
+```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,7 +12,7 @@ curl -L -o oura.tar.gz https://github.com/txpipe/oura/releases/latest/download/o
 
 ### Ubuntu
 
-To install Oura binary in a Mac, use the following shell command:
+To install Oura binary in a Ubuntu running machine, use the following shell command:
 
 ```sh
 curl -L -o oura.tar.gz https://github.com/txpipe/oura/releases/latest/download/oura-x86_64-unknown-linux-gnu.tar.gz && tar xvzf oura.tar.gz && mv oura /usr/local/bin


### PR DESCRIPTION
Hi!, This PR prsents a way of start **oura** using Docker to take advantage from what containers have

## Motivation
In general 2:
* Due to the nature of the containers, It's an easy to run multiplatform  app.
*  It's a kickoff to have a Dockerfile template for the community  to create a binary by themselves and compare them to the artifacts created by github actions. 

## Limitation (at least by now)
* Only works for remotes nodes. 
* Cannot save the logs in a separate volume

## Nice to have (...in a near future maybe)
* A `docker-compose.yml` where oura is deployed near to a Cardano node
* A `docker-compose.yml` where also is deployed near to a ELK where all the logs are pushed. This will require some more machine; but brings an *out of the box* Cardano stack with monitoring.
* If not wated to use a `docker-compose` stack, save log tail in a volume. 