### PR TITLE
Add common data aggregations to events

### DIFF
--- a/src/framework.rs
+++ b/src/framework.rs
@@ -63,12 +63,16 @@ pub enum EventData {
     Block {
         body_size: usize,
         issuer_vkey: String,
+        tx_count: usize,
     },
     Transaction {
         fee: u64,
         ttl: Option<u64>,
         validity_interval_start: Option<u64>,
         network_id: Option<u32>,
+        input_count: usize,
+        output_count: usize,
+        total_output: u64,
     },
     TxInput {
         tx_id: String,

--- a/src/sinks/terminal/format.rs
+++ b/src/sinks/terminal/format.rs
@@ -18,25 +18,35 @@ impl LogLine {
             EventData::Block {
                 body_size,
                 issuer_vkey,
-            } => LogLine {
-                prefix: "BLOCK",
-                color: Color::Magenta,
-                content: format!(
-                    "{{ hash: {}, body size: {}, issues vkey: {}, timestamp: {} }}",
+                tx_count,
+                ..
+            } => {
+                LogLine {
+                    prefix: "BLOCK",
+                    color: Color::Magenta,
+                    content: format!(
+                    "{{ hash: {}, body size: {}, tx_count: {}, issuer vkey: {}, timestamp: {} }}",
                     &source.context.block_hash.as_ref().unwrap_or(&"".to_string()),
                     body_size,
+                    tx_count,
                     issuer_vkey,
                     source.context.timestamp.unwrap_or_default(),
                 ),
-                source,
-                max_width,
-            },
-            EventData::Transaction { fee, ttl, .. } => LogLine {
+                    source,
+                    max_width,
+                }
+            }
+            EventData::Transaction {
+                total_output,
+                fee,
+                ttl,
+                ..
+            } => LogLine {
                 prefix: "TX",
                 color: Color::DarkBlue,
                 content: format!(
-                    "{{ fee: {}, hash: {:?}, ttl: {:?} }}",
-                    fee, &source.context.tx_hash, ttl
+                    "{{ total_output: {}, fee: {}, hash: {:?}, ttl: {:?} }}",
+                    total_output, fee, &source.context.tx_hash, ttl
                 ),
                 source,
                 max_width,

--- a/testdrive/elasticsearch/index-template.json
+++ b/testdrive/elasticsearch/index-template.json
@@ -7,6 +7,9 @@
                 },
                 "block": {
                     "properties": {
+                        "tx_count": {
+                            "type": "long"
+                        },
                         "body_size": {
                             "type": "long"
                         },
@@ -29,6 +32,9 @@
                     "properties": {
                         "block_number": {
                             "type": "long"
+                        },
+                        "block_hash": {
+                            "type": "keyword"
                         },
                         "input_idx": {
                             "type": "long"
@@ -148,6 +154,15 @@
                             "type": "long"
                         },
                         "validity_interval_start": {
+                            "type": "long"
+                        },
+                        "input_count": {
+                            "type": "long"
+                        },
+                        "output_count": {
+                            "type": "long"
+                        },
+                        "total_output": {
                             "type": "long"
                         }
                     }


### PR DESCRIPTION
- add count of transactions to blocks
- add total coin output to transactions
- add input count to transactions
- add output count to transactions
- update terminal formatting output accordingly
- update example ES mappings accordingly