### PR TITLE
feat: Add CIP-25 metadata parser

### DIFF
--- a/src/filters/fingerpint.rs
+++ b/src/filters/fingerpint.rs
@@ -182,12 +182,12 @@ fn build_fingerprint(event: &Event, seed: u32) -> Result<String, Error> {
             .with_slot(&Some(*block_slot))
             .with_prefix("back")
             .append_slice(block_hash)?,
-        EventData::CIP25Asset(CIP25AssetRecord { id, policy, .. }) => b
+        EventData::CIP25Asset(CIP25AssetRecord { policy, asset, .. }) => b
             .with_slot(&event.context.slot)
             .with_prefix("cip25")
             .append_optional(&event.context.tx_hash)?
-            .append_slice(id)?
-            .append_slice(policy)?,
+            .append_slice(policy)?
+            .append_slice(asset)?,
     };
 
     b.build()

--- a/src/filters/fingerpint.rs
+++ b/src/filters/fingerpint.rs
@@ -9,8 +9,8 @@ use log::{debug, warn};
 use serde_derive::Deserialize;
 
 use crate::framework::{
-    new_inter_stage_channel, Error, Event, EventData, FilterConfig, MetadataRecord, MintRecord,
-    OutputAssetRecord, PartialBootstrapResult, StageReceiver,
+    new_inter_stage_channel, CIP25AssetRecord, Error, Event, EventData, FilterConfig,
+    MetadataRecord, MintRecord, OutputAssetRecord, PartialBootstrapResult, StageReceiver,
 };
 
 struct FingerprintBuilder {
@@ -182,6 +182,12 @@ fn build_fingerprint(event: &Event, seed: u32) -> Result<String, Error> {
             .with_slot(&Some(*block_slot))
             .with_prefix("back")
             .append_slice(block_hash)?,
+        EventData::CIP25Asset(CIP25AssetRecord { id, policy, .. }) => b
+            .with_slot(&event.context.slot)
+            .with_prefix("cip25")
+            .append_optional(&event.context.tx_hash)?
+            .append_slice(id)?
+            .append_slice(policy)?,
     };
 
     b.build()

--- a/src/framework.rs
+++ b/src/framework.rs
@@ -74,6 +74,24 @@ impl From<MetadataRecord> for EventData {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CIP25AssetRecord {
+    pub policy: String,
+    pub id: String,
+    pub name: String,
+    pub version: Option<String>,
+    pub image: JsonValue,
+    pub media_type: Option<String>,
+    pub description: Option<JsonValue>,
+    pub raw_json: Option<JsonValue>,
+}
+
+impl From<CIP25AssetRecord> for EventData {
+    fn from(x: CIP25AssetRecord) -> Self {
+        EventData::CIP25Asset(x)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TxInputRecord {
     pub tx_id: String,
     pub index: u64,
@@ -181,6 +199,7 @@ pub enum EventData {
     TxOutput(TxOutputRecord),
     OutputAsset(OutputAssetRecord),
     Metadata(MetadataRecord),
+    CIP25Asset(CIP25AssetRecord),
     Mint(MintRecord),
     Collateral {
         tx_id: String,

--- a/src/framework.rs
+++ b/src/framework.rs
@@ -75,14 +75,14 @@ impl From<MetadataRecord> for EventData {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CIP25AssetRecord {
+    pub version: String,
     pub policy: String,
-    pub id: String,
-    pub name: String,
-    pub version: Option<String>,
-    pub image: JsonValue,
+    pub asset: String,
+    pub name: Option<String>,
+    pub image: Option<String>,
     pub media_type: Option<String>,
-    pub description: Option<JsonValue>,
-    pub raw_json: Option<JsonValue>,
+    pub description: Option<String>,
+    pub raw_json: JsonValue,
 }
 
 impl From<CIP25AssetRecord> for EventData {

--- a/src/mapper/cip25.rs
+++ b/src/mapper/cip25.rs
@@ -1,0 +1,90 @@
+use pallas::ledger::alonzo::Metadatum;
+
+use crate::framework::{CIP25AssetRecord, Error};
+
+use super::EventWriter;
+
+// Heuristic approach for filtering policy entries. This is the best I could
+// come up with. Is there a better, official way?
+fn is_policy_key(key: &Metadatum) -> Option<String> {
+    match key {
+        Metadatum::Bytes(x) if x.len() == 28 => Some(hex::encode(x.as_slice())),
+        Metadatum::Text(x) if x.len() == 56 => Some(x.to_owned()),
+        _ => None,
+    }
+}
+
+// Heuristic approach for filtering asset entries. Even less strict than when
+// searching for policies. In this case, we only check for valid data types.
+// There's probably a much more formal approach.
+fn is_asset_key(key: &Metadatum) -> Option<String> {
+    match key {
+        Metadatum::Bytes(x) => Some(hex::encode(x.as_slice())),
+        Metadatum::Text(x) => Some(x.to_owned()),
+        _ => None,
+    }
+}
+
+impl EventWriter {
+    fn search_cip25_version(&self, content_721: &Metadatum) -> Option<String> {
+        match content_721 {
+            Metadatum::Map(entries) => entries.iter().find_map(|(key, value)| match key {
+                Metadatum::Text(x) if x == "version" => match value {
+                    Metadatum::Text(value) => Some(value.to_owned()),
+                    _ => None,
+                },
+                _ => None,
+            }),
+            _ => None,
+        }
+    }
+
+    fn to_cip25_asset_record(
+        &self,
+        _version: &str,
+        _policy: &str,
+        _asset: &str,
+        _content: &Metadatum,
+    ) -> Result<CIP25AssetRecord, Error> {
+        todo!()
+    }
+
+    fn crawl_721_policy(
+        &self,
+        version: &str,
+        policy: &str,
+        content: &Metadatum,
+    ) -> Result<(), Error> {
+        let entries = match content {
+            Metadatum::Map(map) => map,
+            _ => return Err("expected 721 policy content to be a map".into()),
+        };
+
+        for (key, sub_content) in entries.iter() {
+            if let Some(asset) = is_asset_key(key) {
+                self.to_cip25_asset_record(version, policy, &asset, sub_content)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn crawl_metadata_label_721(&self, content: &Metadatum) -> Result<(), Error> {
+        let version = self
+            .search_cip25_version(content)
+            .unwrap_or_else(|| "1.0".to_string());
+
+        let entries = match content {
+            Metadatum::Map(map) => map,
+            _ => return Err("expected 721 content to be a map".into()),
+        };
+
+        for (key, sub_content) in entries.iter() {
+            if let Some(policy) = is_policy_key(key) {
+                self.crawl_721_policy(&version, &policy, sub_content)?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/mapper/crawl.rs
+++ b/src/mapper/crawl.rs
@@ -1,5 +1,5 @@
 use pallas::ledger::alonzo::{
-    crypto, AuxiliaryData, Block, Certificate, Metadata, Multiasset, TransactionBody,
+    crypto, AuxiliaryData, Block, Certificate, Metadata, Metadatum, Multiasset, TransactionBody,
     TransactionBodyComponent, TransactionInput, TransactionOutput, Value,
 };
 
@@ -9,9 +9,15 @@ use super::{framework::EventWriter, map::ToBech32};
 
 impl EventWriter {
     fn crawl_metadata(&self, metadata: &Metadata) -> Result<(), Error> {
-        for (label, value) in metadata.iter() {
-            let record = self.to_metadata_record(label, value)?;
+        for (label, content) in metadata.iter() {
+            let record = self.to_metadata_record(label, content)?;
             self.append_from(record)?;
+
+            match label {
+                Metadatum::Int(721) => self.crawl_metadata_label_721(content)?,
+                Metadatum::Text(x) if x == "721" => self.crawl_metadata_label_721(content)?,
+                _ => (),
+            };
         }
 
         Ok(())

--- a/src/mapper/crawl.rs
+++ b/src/mapper/crawl.rs
@@ -16,7 +16,7 @@ impl EventWriter {
             match label {
                 Metadatum::Int(721) => self.crawl_metadata_label_721(content)?,
                 Metadatum::Text(x) if x == "721" => self.crawl_metadata_label_721(content)?,
-                _ => (),
+                _ => log::warn!("found label {:?}", label),
             };
         }
 

--- a/src/mapper/mod.rs
+++ b/src/mapper/mod.rs
@@ -1,3 +1,4 @@
+mod cip25;
 mod collect;
 mod crawl;
 mod framework;

--- a/src/sinks/terminal/format.rs
+++ b/src/sinks/terminal/format.rs
@@ -211,8 +211,8 @@ impl LogLine {
                 max_width,
             },
             EventData::CIP25Asset(CIP25AssetRecord {
-                id,
                 policy,
+                asset,
                 name,
                 image,
                 ..
@@ -220,8 +220,11 @@ impl LogLine {
                 prefix: "CIP25",
                 color: Color::DarkYellow,
                 content: format!(
-                    "{{ id: {}, policy: {}, name: {}, image: {} }}",
-                    id, policy, name, image
+                    "{{ policy: {}, asset: {}, name: {}, image: {} }}",
+                    policy,
+                    asset,
+                    name.as_deref().unwrap_or("?"),
+                    image.as_deref().unwrap_or("?")
                 ),
                 source,
                 max_width,

--- a/src/sinks/terminal/format.rs
+++ b/src/sinks/terminal/format.rs
@@ -3,8 +3,8 @@ use std::fmt::{Display, Write};
 use crossterm::style::{Attribute, Color, Stylize};
 
 use crate::framework::{
-    Event, EventData, MetadataRecord, MintRecord, OutputAssetRecord, TransactionRecord,
-    TxInputRecord, TxOutputRecord,
+    CIP25AssetRecord, Event, EventData, MetadataRecord, MintRecord, OutputAssetRecord,
+    TransactionRecord, TxInputRecord, TxOutputRecord,
 };
 
 pub struct LogLine {
@@ -207,6 +207,22 @@ impl LogLine {
                 prefix: "COLLAT",
                 color: Color::Blue,
                 content: format!("{{ tx_id: {}, index: {} }}", tx_id, index),
+                source,
+                max_width,
+            },
+            EventData::CIP25Asset(CIP25AssetRecord {
+                id,
+                policy,
+                name,
+                image,
+                ..
+            }) => LogLine {
+                prefix: "CIP25",
+                color: Color::DarkYellow,
+                content: format!(
+                    "{{ id: {}, policy: {}, name: {}, image: {} }}",
+                    id, policy, name, image
+                ),
                 source,
                 max_width,
             },


### PR DESCRIPTION
This new parser will inspect metadata records looking for CIP-25 compliance. If found, a new event will be sent for each asset in the policy with the following structure:

```rust
pub struct CIP25AssetRecord {
    pub policy: String,
    pub id: String,
    pub name: String,
    pub version: Option<String>,
    pub image: JsonValue,
    pub media_type: Option<String>,
    pub description: Option<JsonValue>,
    pub raw_json: Option<JsonValue>,
}
```