### PR TITLE
fix: EventWriter::standalone() inaccessible

### DIFF
--- a/src/mapper/prelude.rs
+++ b/src/mapper/prelude.rs
@@ -26,7 +26,7 @@ pub struct Config {
 }
 
 #[derive(Clone)]
-pub(crate) struct EventWriter {
+pub struct EventWriter {
     context: EventContext,
     output: StageSender,
     pub(crate) config: Config,


### PR DESCRIPTION
There's one left over to make the `EventWriter::standalone()` actually work for code examples. The struct must be public.

```
error[E0603]: struct `EventWriter` is private
  --> examples/blockfetch.rs:19:13
   |
19 |     mapper::EventWriter,
   |             ^^^^^^^^^^^ private struct
   |
```