### PR TITLE
BlockRecord: include previous block hash

### DIFF
--- a/src/mapper/map.rs
+++ b/src/mapper/map.rs
@@ -353,6 +353,7 @@ impl EventWriter {
             hash: hex::encode(hash),
             number: source.header.header_body.block_number,
             slot: source.header.header_body.slot,
+            previous_hash: hex::encode(source.header.header_body.prev_hash),
         })
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -164,6 +164,7 @@ pub struct BlockRecord {
     pub slot: u64,
     pub hash: String,
     pub number: u64,
+    pub previous_hash: String,
 }
 
 #[derive(Serialize, Deserialize, Display, Debug, Clone)]


### PR DESCRIPTION
* hex encode the previous block hash from the block header body
* include it in struct `BlockRecord`