### PR TITLE
feat(ci): Implement integration testing

### DIFF
--- a/.github/workflows/integration-testing.yaml
+++ b/.github/workflows/integration-testing.yaml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: network=host
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/integration-testing.yaml
+++ b/.github/workflows/integration-testing.yaml
@@ -21,11 +21,21 @@ jobs:
         with:
           channel: 'latest/stable'
           addons: '["registry"]'
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+
       - name: Build and push
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/integration-testing.yaml
+++ b/.github/workflows/integration-testing.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v1
+        uses: docker/metadata-action@v3
         with:
           tags: |
             type=raw,value=latest

--- a/.github/workflows/integration-testing.yaml
+++ b/.github/workflows/integration-testing.yaml
@@ -38,6 +38,8 @@ jobs:
         id: meta
         uses: docker/metadata-action@v1
         with:
+          flavor: |
+            latest=true
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push

--- a/.github/workflows/integration-testing.yaml
+++ b/.github/workflows/integration-testing.yaml
@@ -38,8 +38,8 @@ jobs:
         id: meta
         uses: docker/metadata-action@v1
         with:
-          flavor: |
-            latest=true
+        tags: |
+          type=raw,value=latest
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push

--- a/.github/workflows/integration-testing.yaml
+++ b/.github/workflows/integration-testing.yaml
@@ -17,10 +17,17 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-      - uses: balchua/microk8s-actions@v0.2.1
+      - name: Set-up microk8s instance with registry
+        uses: balchua/microk8s-actions@v0.2.1
         with:
           channel: 'latest/stable'
           addons: '["registry"]'
+
+      - name: Test MicroK8s
+        id: myactions
+        run: |
+          kubectl get no
+          kubectl get pods -A -o wide
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -30,11 +37,6 @@ jobs:
         uses: docker/metadata-action@v1
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ env.REGISTRY }}
 
       - name: Build and push
         uses: docker/build-push-action@v2

--- a/.github/workflows/integration-testing.yaml
+++ b/.github/workflows/integration-testing.yaml
@@ -38,8 +38,8 @@ jobs:
         id: meta
         uses: docker/metadata-action@v1
         with:
-        tags: |
-          type=raw,value=latest
+          tags: |
+            type=raw,value=latest
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push

--- a/.github/workflows/integration-testing.yaml
+++ b/.github/workflows/integration-testing.yaml
@@ -6,10 +6,6 @@ on:
 
 name: Integration tests
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
   microk8s:
     name: Set-up MicroK8s single node instance
@@ -20,3 +16,17 @@ jobs:
       - uses: balchua/microk8s-actions@v0.2.1
         with:
           channel: 'latest/stable'
+          addons: '["registry"]'
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v1
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/integration-testing.yaml
+++ b/.github/workflows/integration-testing.yaml
@@ -6,6 +6,10 @@ on:
 
 name: Integration tests
 
+env:
+  REGISTRY: localhost:32000
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   microk8s:
     name: Set-up MicroK8s single node instance

--- a/.github/workflows/integration-testing.yaml
+++ b/.github/workflows/integration-testing.yaml
@@ -1,19 +1,22 @@
 on:
   pull_request:
     # Sequence of patterns matched against refs/heads
-    branches:    
+    branches:
       - main
-      
+
 name: Integration tests
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
-  <job-id>:
-    name: Check
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout sources
-          uses: actions/checkout@v2
-        - uses: balchua/microk8s-actions@v0.2.1
-          with:
-            channel: 'latest/stable'
-          
+  microk8s:
+    name: Set-up MicroK8s single node instance
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - uses: balchua/microk8s-actions@v0.2.1
+        with:
+          channel: 'latest/stable'

--- a/.github/workflows/integration-testing.yaml
+++ b/.github/workflows/integration-testing.yaml
@@ -1,0 +1,19 @@
+on:
+  pull_request:
+    # Sequence of patterns matched against refs/heads
+    branches:    
+      - main
+      
+name: Integration tests
+
+jobs:
+  <job-id>:
+    name: Check
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout sources
+          uses: actions/checkout@v2
+        - uses: balchua/microk8s-actions@v0.2.1
+          with:
+            channel: 'latest/stable'
+          


### PR DESCRIPTION
I would write a shell script that would sync with IOG testnet and mainnet nodes, I would like to "randomly" connect to the respective networks and I can get all the info I need using few lines of python or a bash script if you don't want to introduce that dependency.

I have not thought about testing the UNIX (N2C), and I think it would take too long to sync, however maybe a separate branch to hold the database of `cardano-node` can be used, so that the `cardano-node` running in our GitHub runners would not have to always sync from genesis, but could start at the last termination point, or we could even implement a cron-like workglow to sync it once a week or so; but we would keep that data dump in a separate branch, or even better, I can just put it on an external webserver and download over HTTPS, decompress and start the `cardano-node`, what do you think?

While I can implement it without #93, if I want it to be graceful, considering GH Runners have a maximal runtime, https://github.com/txpipe/oura/issues/97 is a hard requirement to implement this.