### PR TITLE
ci: Remove i686 release targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,6 @@ jobs:
             os: ubuntu-latest
             name: oura-x86_64-unknown-linux-musl.tar.gz
 
-          - target: i686-unknown-linux-musl
-            os: ubuntu-latest
-            name: oura-i686-unknown-linux-musl.tar.gz
-
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             name: oura-aarch64-unknown-linux-musl.tar.gz
@@ -47,10 +43,6 @@ jobs:
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             name: oura-x86_64-pc-windows-msvc.zip
-
-          - target: i686-pc-windows-msvc
-            os: windows-latest
-            name: oura-i686-pc-windows-msvc.zip
 
           - target: aarch64-pc-windows-msvc
             os: windows-latest


### PR DESCRIPTION
**i686** is too legacy for [cryptoxide v0.4.2](https://docs.rs/cryptoxide/0.4.2/cryptoxide/) which requires [_mm256_permute4x64_epi64](https://docs.rs/stdsimd/0.1.2/stdsimd/arch/x86_64/fn._mm256_permute4x64_epi64.html) which is supported on x86-64 and target feature avx2 only.