### PR TITLE
ci(dependabot): Auto-update GH Action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@
 
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/.github/workflows/"
+    schedule:
+      interval: "daily"
   - package-ecosystem: "cargo" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:


### PR DESCRIPTION
I have noticed release workflow is using outdated Docker actions when working on https://github.com/txpipe/oura/pull/128, we may as well include it in Dependabot config.