### PR TITLE
feat: Introduce the 'Assert' sink

### DIFF
--- a/src/bin/oura/daemon.rs
+++ b/src/bin/oura/daemon.rs
@@ -16,6 +16,7 @@ use oura::{
 
 use oura::filters::noop::Config as NoopFilterConfig;
 use oura::filters::selection::Config as SelectionConfig;
+use oura::sinks::assert::Config as AssertConfig;
 use oura::sinks::stdout::Config as StdoutConfig;
 use oura::sinks::terminal::Config as TerminalConfig;
 use oura::sources::n2c::Config as N2CConfig;
@@ -77,6 +78,7 @@ impl FilterProvider for Filter {
 enum Sink {
     Terminal(TerminalConfig),
     Stdout(StdoutConfig),
+    Assert(AssertConfig),
 
     #[cfg(feature = "logs")]
     Logs(WriterConfig),
@@ -95,6 +97,7 @@ fn bootstrap_sink(config: Sink, input: StageReceiver, utils: Arc<Utils>) -> Boot
     match config {
         Sink::Terminal(c) => WithUtils::new(c, utils).bootstrap(input),
         Sink::Stdout(c) => WithUtils::new(c, utils).bootstrap(input),
+        Sink::Assert(c) => WithUtils::new(c, utils).bootstrap(input),
 
         #[cfg(feature = "logs")]
         Sink::Logs(c) => WithUtils::new(c, utils).bootstrap(input),

--- a/src/sinks/assert/checks.rs
+++ b/src/sinks/assert/checks.rs
@@ -30,3 +30,15 @@ pub(crate) fn block_previous_hash_matches(state: &State) -> Outcome {
         _ => Outcome::Unknown,
     }
 }
+
+pub(crate) fn tx_records_matches_block_count(state: &State) -> Outcome {
+    match &state.current_event {
+        Some(event) => match &event.data {
+            crate::model::EventData::BlockEnd(block) => {
+                Outcome::from(block.tx_count == state.tx_count_in_block)
+            }
+            _ => Outcome::Unknown,
+        },
+        _ => Outcome::Unknown,
+    }
+}

--- a/src/sinks/assert/checks.rs
+++ b/src/sinks/assert/checks.rs
@@ -50,7 +50,7 @@ pub(crate) fn tx_has_input_and_output(state: &State) -> Outcome {
         Some(event) => match &event.data {
             EventData::Transaction(tx) => match (&tx.inputs, &tx.outputs) {
                 (Some(inputs), Some(outputs)) => {
-                    Outcome::from(inputs.len() > 0 && outputs.len() > 0)
+                    Outcome::from(!inputs.is_empty() && !outputs.is_empty())
                 }
                 _ => Outcome::Unknown,
             },

--- a/src/sinks/assert/checks.rs
+++ b/src/sinks/assert/checks.rs
@@ -39,7 +39,7 @@ pub(crate) fn tx_records_matches_block_count(state: &State) -> Outcome {
             EventData::BlockEnd(block) => {
                 Outcome::from(block.tx_count == state.tx_records_since_block)
             }
-            _ => Outcome::Unknown,
+            _ => Outcome::NotApplicable,
         },
         _ => Outcome::Unknown,
     }
@@ -50,11 +50,11 @@ pub(crate) fn tx_has_input_and_output(state: &State) -> Outcome {
         Some(event) => match &event.data {
             EventData::Transaction(tx) => match (&tx.inputs, &tx.outputs) {
                 (Some(inputs), Some(outputs)) => {
-                    Outcome::from(inputs.len() > 1 && outputs.len() > 1)
+                    Outcome::from(inputs.len() > 0 && outputs.len() > 0)
                 }
                 _ => Outcome::Unknown,
             },
-            _ => Outcome::Unknown,
+            _ => Outcome::NotApplicable,
         },
         _ => Outcome::Unknown,
     }

--- a/src/sinks/assert/checks.rs
+++ b/src/sinks/assert/checks.rs
@@ -1,3 +1,5 @@
+use crate::model::EventData;
+
 use super::prelude::*;
 
 pub(crate) fn block_depth_doesnt_skip_numbers(state: &State) -> Outcome {
@@ -34,9 +36,24 @@ pub(crate) fn block_previous_hash_matches(state: &State) -> Outcome {
 pub(crate) fn tx_records_matches_block_count(state: &State) -> Outcome {
     match &state.current_event {
         Some(event) => match &event.data {
-            crate::model::EventData::BlockEnd(block) => {
-                Outcome::from(block.tx_count == state.tx_count_in_block)
+            EventData::BlockEnd(block) => {
+                Outcome::from(block.tx_count == state.tx_records_since_block)
             }
+            _ => Outcome::Unknown,
+        },
+        _ => Outcome::Unknown,
+    }
+}
+
+pub(crate) fn tx_has_input_and_output(state: &State) -> Outcome {
+    match &state.current_event {
+        Some(event) => match &event.data {
+            EventData::Transaction(tx) => match (&tx.inputs, &tx.outputs) {
+                (Some(inputs), Some(outputs)) => {
+                    Outcome::from(inputs.len() > 1 && outputs.len() > 1)
+                }
+                _ => Outcome::Unknown,
+            },
             _ => Outcome::Unknown,
         },
         _ => Outcome::Unknown,

--- a/src/sinks/assert/checks.rs
+++ b/src/sinks/assert/checks.rs
@@ -1,0 +1,32 @@
+use super::prelude::*;
+
+pub(crate) fn block_depth_doesnt_skip_numbers(state: &State) -> Outcome {
+    match (&state.previous_block, &state.current_block) {
+        (Some(prev), Some(curr)) => Outcome::from((curr.number - prev.number) == 1),
+        _ => Outcome::Unknown,
+    }
+}
+
+pub(crate) fn block_slot_increases(state: &State) -> Outcome {
+    match (&state.previous_block, &state.current_block) {
+        (Some(prev), Some(curr)) => Outcome::from(prev.slot < curr.slot),
+        _ => Outcome::Unknown,
+    }
+}
+
+pub(crate) fn event_timestamp_increases(state: &State) -> Outcome {
+    match (&state.previous_event, &state.current_event) {
+        (Some(prev), Some(curr)) => match (prev.context.timestamp, curr.context.timestamp) {
+            (Some(prev), Some(curr)) => Outcome::from(prev <= curr),
+            _ => Outcome::Unknown,
+        },
+        _ => Outcome::Unknown,
+    }
+}
+
+pub(crate) fn block_previous_hash_matches(state: &State) -> Outcome {
+    match (&state.previous_block, &state.current_block) {
+        (Some(prev), Some(curr)) => Outcome::from(curr.previous_hash == prev.hash),
+        _ => Outcome::Unknown,
+    }
+}

--- a/src/sinks/assert/mod.rs
+++ b/src/sinks/assert/mod.rs
@@ -1,0 +1,4 @@
+mod run;
+mod setup;
+
+pub use setup::*;

--- a/src/sinks/assert/mod.rs
+++ b/src/sinks/assert/mod.rs
@@ -1,3 +1,5 @@
+mod checks;
+mod prelude;
 mod run;
 mod setup;
 

--- a/src/sinks/assert/prelude.rs
+++ b/src/sinks/assert/prelude.rs
@@ -1,0 +1,24 @@
+use crate::model::{BlockRecord, Event};
+
+#[derive(Default, Debug)]
+pub(crate) struct State {
+    pub current_event: Option<Event>,
+    pub previous_event: Option<Event>,
+    pub current_block: Option<BlockRecord>,
+    pub previous_block: Option<BlockRecord>,
+}
+
+pub(crate) enum Outcome {
+    Pass,
+    Fail,
+    Unknown,
+}
+
+impl From<bool> for Outcome {
+    fn from(other: bool) -> Self {
+        match other {
+            true => Outcome::Pass,
+            false => Outcome::Fail,
+        }
+    }
+}

--- a/src/sinks/assert/prelude.rs
+++ b/src/sinks/assert/prelude.rs
@@ -6,7 +6,7 @@ pub(crate) struct State {
     pub previous_event: Option<Event>,
     pub current_block: Option<BlockRecord>,
     pub previous_block: Option<BlockRecord>,
-    pub tx_count_in_block: usize,
+    pub tx_records_since_block: usize,
 }
 
 pub(crate) enum Outcome {

--- a/src/sinks/assert/prelude.rs
+++ b/src/sinks/assert/prelude.rs
@@ -12,6 +12,7 @@ pub(crate) struct State {
 pub(crate) enum Outcome {
     Pass,
     Fail,
+    NotApplicable,
     Unknown,
 }
 

--- a/src/sinks/assert/prelude.rs
+++ b/src/sinks/assert/prelude.rs
@@ -6,6 +6,7 @@ pub(crate) struct State {
     pub previous_event: Option<Event>,
     pub current_block: Option<BlockRecord>,
     pub previous_block: Option<BlockRecord>,
+    pub tx_count_in_block: usize,
 }
 
 pub(crate) enum Outcome {

--- a/src/sinks/assert/run.rs
+++ b/src/sinks/assert/run.rs
@@ -11,7 +11,7 @@ use super::checks::*;
 use super::prelude::*;
 use super::Config;
 
-macro_rules! execute_assertion {
+macro_rules! run_check {
     ($config:expr, $state:expr, $func:ident) => {
         let outcome = $func($state);
         let name = stringify!($func);
@@ -79,11 +79,11 @@ pub fn assertion_loop(
 
         state = reduce_state(state, event);
 
-        execute_assertion!(&config, &state, block_depth_doesnt_skip_numbers);
-        execute_assertion!(&config, &state, block_slot_increases);
-        execute_assertion!(&config, &state, block_previous_hash_matches);
-        execute_assertion!(&config, &state, event_timestamp_increases);
-        execute_assertion!(&config, &state, tx_records_matches_block_count);
-        execute_assertion!(&config, &state, tx_has_input_and_output);
+        run_check!(&config, &state, block_depth_doesnt_skip_numbers);
+        run_check!(&config, &state, block_slot_increases);
+        run_check!(&config, &state, block_previous_hash_matches);
+        run_check!(&config, &state, event_timestamp_increases);
+        run_check!(&config, &state, tx_records_matches_block_count);
+        run_check!(&config, &state, tx_has_input_and_output);
     }
 }

--- a/src/sinks/assert/run.rs
+++ b/src/sinks/assert/run.rs
@@ -44,11 +44,11 @@ fn reduce_state(current: State, event: Event) -> State {
         EventData::Block(r) => State {
             previous_block: current.current_block,
             current_block: Some(r.clone()),
-            tx_count_in_block: 0,
+            tx_records_since_block: 0,
             ..current
         },
         EventData::Transaction(_) => State {
-            tx_count_in_block: current.tx_count_in_block + 1,
+            tx_records_since_block: current.tx_records_since_block + 1,
             ..current
         },
         _ => current,
@@ -83,5 +83,6 @@ pub fn assertion_loop(
         execute_assertion!(&config, &state, block_previous_hash_matches);
         execute_assertion!(&config, &state, event_timestamp_increases);
         execute_assertion!(&config, &state, tx_records_matches_block_count);
+        execute_assertion!(&config, &state, tx_has_input_and_output);
     }
 }

--- a/src/sinks/assert/run.rs
+++ b/src/sinks/assert/run.rs
@@ -1,0 +1,146 @@
+use std::sync::Arc;
+
+use crate::{
+    model::{BlockRecord, Event, EventData},
+    pipelining::StageReceiver,
+    utils::Utils,
+    Error,
+};
+
+use super::Config;
+
+#[derive(Default, Debug)]
+struct State {
+    current_event: Option<Event>,
+    previous_event: Option<Event>,
+    current_block: Option<BlockRecord>,
+    previous_block: Option<BlockRecord>,
+}
+
+enum Outcome {
+    Pass,
+    Fail,
+    Unknown,
+}
+
+impl From<bool> for Outcome {
+    fn from(other: bool) -> Self {
+        match other {
+            true => Outcome::Pass,
+            false => Outcome::Fail,
+        }
+    }
+}
+
+macro_rules! execute_assertion {
+    ($config:expr, $state:expr, $func:ident) => {
+        let outcome = $func($state);
+        let name = stringify!($func);
+
+        if $config.skip_assertions.iter().any(|x| x.eq(&name)) {
+            log::debug!("skipped assertion: {}", name);
+        } else {
+            match outcome {
+                Outcome::Pass => {
+                    log::info!("passed assertion: {}", name);
+                }
+                Outcome::Fail => {
+                    log::error!("failed assertion: {}", name);
+                    dbg!($state);
+
+                    if $config.break_on_failure {
+                        panic!();
+                    }
+                }
+                Outcome::Unknown => {
+                    log::warn!("unknown assertion outcome: {}", name);
+                }
+            };
+        }
+    };
+}
+
+fn block_depth_doesnt_skip_numbers(state: &State) -> Outcome {
+    match (&state.previous_block, &state.current_block) {
+        (Some(prev), Some(curr)) => Outcome::from((curr.number - prev.number) == 1),
+        _ => Outcome::Unknown,
+    }
+}
+
+fn block_slot_increases(state: &State) -> Outcome {
+    match (&state.previous_block, &state.current_block) {
+        (Some(prev), Some(curr)) => Outcome::from(prev.slot < curr.slot),
+        _ => Outcome::Unknown,
+    }
+}
+
+fn event_timestamp_increases(state: &State) -> Outcome {
+    match (&state.previous_event, &state.current_event) {
+        (Some(prev), Some(curr)) => match (prev.context.timestamp, curr.context.timestamp) {
+            (Some(prev), Some(curr)) => Outcome::from(prev <= curr),
+            _ => Outcome::Unknown,
+        },
+        _ => Outcome::Unknown,
+    }
+}
+
+fn block_previous_hash_matches(state: &State) -> Outcome {
+    match (&state.previous_block, &state.current_block) {
+        (Some(prev), Some(curr)) => Outcome::from(curr.previous_hash == prev.hash),
+        _ => Outcome::Unknown,
+    }
+}
+
+/*
+fn cbor_decoding_is_isomorphic(state: &State) -> bool {
+    match state.latest_event {
+        Some(event) => match event.data {
+            EventData::Block(block) => {
+
+            }
+        }
+    }
+}
+ */
+fn reduce_state(current: State, event: Event) -> State {
+    let state = match &event.data {
+        EventData::Block(r) => State {
+            previous_block: current.current_block,
+            current_block: Some(r.clone()),
+            ..current
+        },
+        _ => current,
+    };
+
+    let state = State {
+        previous_event: state.current_event,
+        current_event: Some(event),
+        ..state
+    };
+
+    state
+}
+
+pub fn assertion_loop(
+    input: StageReceiver,
+    config: Config,
+    utils: Arc<Utils>,
+) -> Result<(), Error> {
+    let mut state = State::default();
+
+    loop {
+        let event = input.recv()?;
+
+        // notify pipeline about the progress
+        utils.track_sink_progress(&event);
+
+        log::info!("starting assertions for event: {:?}", event.fingerprint);
+
+        state = reduce_state(state, event);
+
+        execute_assertion!(&config, &state, block_depth_doesnt_skip_numbers);
+        execute_assertion!(&config, &state, block_slot_increases);
+        execute_assertion!(&config, &state, block_previous_hash_matches);
+        execute_assertion!(&config, &state, event_timestamp_increases);
+    }
+}

--- a/src/sinks/assert/run.rs
+++ b/src/sinks/assert/run.rs
@@ -34,6 +34,7 @@ macro_rules! execute_assertion {
                 Outcome::Unknown => {
                     log::warn!("unknown assertion outcome: {}", name);
                 }
+                Outcome::NotApplicable => (),
             };
         }
     };

--- a/src/sinks/assert/run.rs
+++ b/src/sinks/assert/run.rs
@@ -44,6 +44,11 @@ fn reduce_state(current: State, event: Event) -> State {
         EventData::Block(r) => State {
             previous_block: current.current_block,
             current_block: Some(r.clone()),
+            tx_count_in_block: 0,
+            ..current
+        },
+        EventData::Transaction(_) => State {
+            tx_count_in_block: current.tx_count_in_block + 1,
             ..current
         },
         _ => current,
@@ -77,5 +82,6 @@ pub fn assertion_loop(
         execute_assertion!(&config, &state, block_slot_increases);
         execute_assertion!(&config, &state, block_previous_hash_matches);
         execute_assertion!(&config, &state, event_timestamp_increases);
+        execute_assertion!(&config, &state, tx_records_matches_block_count);
     }
 }

--- a/src/sinks/assert/setup.rs
+++ b/src/sinks/assert/setup.rs
@@ -1,0 +1,31 @@
+use serde::Deserialize;
+
+use crate::{
+    pipelining::{BootstrapResult, SinkProvider, StageReceiver},
+    utils::WithUtils,
+};
+
+use super::run::assertion_loop;
+
+#[derive(Default, Debug, Deserialize, Clone)]
+pub struct Config {
+    #[serde(default)]
+    pub break_on_failure: bool,
+
+    #[serde(default = "Vec::new")]
+    pub skip_assertions: Vec<String>,
+}
+
+impl SinkProvider for WithUtils<Config> {
+    fn bootstrap(&self, input: StageReceiver) -> BootstrapResult {
+        let utils = self.utils.clone();
+
+        let config = self.inner.clone();
+
+        let handle = std::thread::spawn(move || {
+            assertion_loop(input, config, utils).expect("assertion loop failed")
+        });
+
+        Ok(handle)
+    }
+}

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -1,3 +1,4 @@
+pub mod assert;
 pub mod stdout;
 pub mod terminal;
 


### PR DESCRIPTION
With the goal of moving towards a CD pipeline, we introduce a new `Assert` sink.

The sink works by consuming incoming events and running an expanding set of "assertions" for each one. The result of the assertions are logged. If specified via configuration, a failed assertion will panic and terminate the pipeline (useful for automation).

In this initial PR we're including the following set of assertions:

`block_depth_doesnt_skip_numbers`
`block_slot_increases`
`block_previous_hash_matches`
`event_timestamp_increases`
`tx_records_matches_block_count`

Ideally, we'll keep growing the list with more specific checks for each event. There's also room for adding checks that include well-known, expected values (aka: asserting values for particular blocks).

The end-goal is to have a comprehensive set of assertions that can be used in automated integration tests, providing a fast mechanism for catching regressions on each new PR.

Implementation details:

- the sink maintains a `state` object which is the result of a "reduce" algorithm over the previous state and the current event. This is required since many of the interesting checks involve looking into the history of past events.
- we use macros to improve readability without sacrifying static dispatches.