### PR TITLE
feat: Implement Prometheus metric exporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "ascii"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf56136a5198c7b01a49e3afcbef6cf84597273d298f54432926024107b0109"
+
+[[package]]
 name = "async-compression"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,9 +176,15 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
+ "time 0.1.44",
  "winapi",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "clap"
@@ -985,6 +997,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,6 +1092,7 @@ dependencies = [
  "net2",
  "openssl",
  "pallas",
+ "prometheus_exporter",
  "reqwest",
  "serde",
  "serde_json",
@@ -1253,6 +1275,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f64969ffd5dd8f39bd57a68ac53c163a095ed9d0fb707146da1b27025a3504"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot 0.11.2",
+ "thiserror",
+]
+
+[[package]]
+name = "prometheus_exporter"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "019a192344efa197e8edfb2b864a5369ba8a837578d1bee469f21d98a8ed1233"
+dependencies = [
+ "ascii",
+ "prometheus",
+ "thiserror",
+ "tiny_http",
 ]
 
 [[package]]
@@ -1692,6 +1740,37 @@ dependencies = [
  "libc",
  "wasi",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
+dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
+ "time-macros",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
+
+[[package]]
+name = "tiny_http"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f8734c6d6943ad6df6b588d228a87b4af184998bcffa268ceddf05c2055a8c"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "log 0.4.14",
+ "time 0.3.7",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = "1.0.78"
 strum = "0.23"
 strum_macros = "0.23"
 minicbor = "0.13"
+prometheus_exporter = { version = "0.8.4", default-features = false }
 
 # feature logs
 file-rotate = { version = "0.6.0", optional = true }
@@ -50,15 +51,11 @@ tokio = { version = "1.17.0", optional = true, features = ["rt"] }
 # feature: fingerprint
 murmur3 = { version = "0.5.1", optional = true }
 
-# feature: metrics
-prometheus_exporter = { version = "0.8.4", default-features = false, optional = true }
-
 # required for CI to complete successfully
 openssl = { version = "0.10", optional = true, features = ["vendored"] }
 
 [features]
 default = []
-metrics = ["prometheus_exporter"]
 logs = ["file-rotate"]
 webhook = ["reqwest"]
 tuisink = ["tui"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,11 +50,15 @@ tokio = { version = "1.17.0", optional = true, features = ["rt"] }
 # feature: fingerprint
 murmur3 = { version = "0.5.1", optional = true }
 
+# feature: metrics
+prometheus_exporter = { version = "0.8.4", default-features = false, optional = true }
+
 # required for CI to complete successfully
 openssl = { version = "0.10", optional = true, features = ["vendored"] }
 
 [features]
 default = []
+metrics = ["prometheus_exporter"]
 logs = ["file-rotate"]
 webhook = ["reqwest"]
 tuisink = ["tui"]

--- a/src/bin/oura/dump.rs
+++ b/src/bin/oura/dump.rs
@@ -106,7 +106,7 @@ pub fn run(args: &ArgMatches) -> Result<(), Error> {
 
     // TODO: map add cli arg to enable / disable cursor
 
-    let utils = Arc::new(Utils::new(well_known, None));
+    let utils = Arc::new(Utils::new(well_known));
 
     #[allow(deprecated)]
     let source_setup = match mode {

--- a/src/bin/oura/watch.rs
+++ b/src/bin/oura/watch.rs
@@ -84,7 +84,7 @@ pub fn run(args: &ArgMatches) -> Result<(), Error> {
 
     let well_known = ChainWellKnownInfo::try_from_magic(*magic)?;
 
-    let utils = Arc::new(Utils::new(well_known, None));
+    let utils = Arc::new(Utils::new(well_known));
 
     #[allow(deprecated)]
     let source_setup = match mode {

--- a/src/mapper/prelude.rs
+++ b/src/mapper/prelude.rs
@@ -52,7 +52,7 @@ impl EventWriter {
         well_known: Option<ChainWellKnownInfo>,
         config: Config,
     ) -> Self {
-        let utils = Arc::new(Utils::new(well_known.unwrap_or_default(), None));
+        let utils = Arc::new(Utils::new(well_known.unwrap_or_default()));
 
         Self::new(output, utils, config)
     }

--- a/src/mapper/prelude.rs
+++ b/src/mapper/prelude.rs
@@ -64,6 +64,8 @@ impl EventWriter {
             fingerprint: None,
         };
 
+        self.utils.track_source_progress(&evt);
+
         self.output
             .send(evt)
             .expect("error sending event through output stage, pipeline must have crashed.");

--- a/src/sources/n2c/run.rs
+++ b/src/sources/n2c/run.rs
@@ -36,7 +36,7 @@ impl chainsync::Observer<chainsync::BlockContent> for ChainObserver {
     fn on_roll_forward(
         &mut self,
         content: chainsync::BlockContent,
-        _tip: &chainsync::Tip,
+        tip: &chainsync::Tip,
     ) -> Result<(), Box<dyn std::error::Error>> {
         // parse the block and extract the point of the chain
         let cbor = Vec::from(content.deref());
@@ -72,6 +72,9 @@ impl chainsync::Observer<chainsync::BlockContent> for ChainObserver {
         }
 
         log_buffer_state(&self.chain_buffer);
+
+        // notify chain tip to the pipeline metrics
+        self.event_writer.utils.track_chain_tip(tip.1);
 
         Ok(())
     }

--- a/src/sources/n2n/run.rs
+++ b/src/sources/n2n/run.rs
@@ -75,7 +75,7 @@ impl chainsync::Observer<chainsync::HeaderContent> for &mut ChainObserver {
     fn on_roll_forward(
         &mut self,
         content: chainsync::HeaderContent,
-        _tip: &chainsync::Tip,
+        tip: &chainsync::Tip,
     ) -> Result<(), Error> {
         // parse the header and extract the point of the chain
         let header = MultiEraHeader::try_from(content)?;
@@ -96,6 +96,9 @@ impl chainsync::Observer<chainsync::HeaderContent> for &mut ChainObserver {
         }
 
         log_buffer_state(&self.chain_buffer);
+
+        // notify chain tip to the pipeline metrics
+        self.event_writer.utils.track_chain_tip(tip.1);
 
         Ok(())
     }

--- a/src/utils/facade.rs
+++ b/src/utils/facade.rs
@@ -13,8 +13,9 @@ impl Utils {
 
     /// To be used by sink stages to track progress
     pub fn track_source_progress(&self, event: &Event) {
-        #[cfg(feature = "metrics")]
-        self.metrics.on_source_event(event);
+        if let Some(metrics) = &self.metrics {
+            metrics.on_source_event(event);
+        }
     }
 
     /// To be used by sink stages to track progress
@@ -28,11 +29,11 @@ impl Utils {
             cursor.set_cursor(point).ok_or_warn("failed to set cursor")
         }
 
-        #[cfg(feature = "metrics")]
-        self.metrics.on_sink_event(event);
+        if let Some(metrics) = &self.metrics {
+            metrics.on_sink_event(event);
+        }
     }
 
-    #[cfg(feature = "metrics")]
     pub fn track_chain_tip(&self, tip: impl Into<metrics::Tip>) {
         //self.metrics.update_chain_state(metrics::ChainState {
         //    tip: Some(tip.into()),

--- a/src/utils/facade.rs
+++ b/src/utils/facade.rs
@@ -12,6 +12,12 @@ impl Utils {
     }
 
     /// To be used by sink stages to track progress
+    pub fn track_source_progress(&self, event: &Event) {
+        #[cfg(feature = "metrics")]
+        self.metrics.on_source_event(event);
+    }
+
+    /// To be used by sink stages to track progress
     pub fn track_sink_progress(&self, event: &Event) {
         let point = match (event.context.slot, &event.context.block_hash) {
             (Some(slot), Some(hash)) => cursor::PointArg(slot, hash.to_owned()),
@@ -22,6 +28,15 @@ impl Utils {
             cursor.set_cursor(point).ok_or_warn("failed to set cursor")
         }
 
-        // TODO: add here future telemetry implementation
+        #[cfg(feature = "metrics")]
+        self.metrics.on_sink_event(event);
+    }
+
+    #[cfg(feature = "metrics")]
+    pub fn track_chain_tip(&self, tip: impl Into<metrics::Tip>) {
+        //self.metrics.update_chain_state(metrics::ChainState {
+        //    tip: Some(tip.into()),
+        //    ..Default::default()
+        //})
     }
 }

--- a/src/utils/facade.rs
+++ b/src/utils/facade.rs
@@ -34,10 +34,9 @@ impl Utils {
         }
     }
 
-    pub fn track_chain_tip(&self, tip: impl Into<metrics::Tip>) {
-        //self.metrics.update_chain_state(metrics::ChainState {
-        //    tip: Some(tip.into()),
-        //    ..Default::default()
-        //})
+    pub fn track_chain_tip(&self, tip: u64) {
+        if let Some(metrics) = &self.metrics {
+            metrics.on_chain_tip(tip);
+        }
     }
 }

--- a/src/utils/metrics.rs
+++ b/src/utils/metrics.rs
@@ -1,0 +1,96 @@
+///! An utility to keep track of the progress of the pipeline as a whole
+use prometheus_exporter::{
+    prometheus::{register_counter, register_int_gauge, Counter, IntGauge},
+};
+
+use merge::Merge;
+
+use crate::{
+    model::{Event, EventData},
+    Error,
+};
+
+#[derive(Clone)]
+pub struct Tip {
+    pub block: u64,
+    pub slot: u64,
+}
+
+#[derive(Default, Merge, Clone)]
+pub(crate) struct ChainState {
+    pub tip: Option<Tip>,
+}
+
+pub(crate) struct Provider {
+    pub chain_tip: IntGauge,
+    pub rollback_count: Counter,
+    pub source_current_slot: IntGauge,
+    pub source_current_height: IntGauge,
+    pub source_event_count: Counter,
+    pub sink_current_slot: IntGauge,
+    pub sink_event_count: Counter,
+}
+
+impl Provider {
+    pub(crate) fn start() -> Result<Self, Error> {
+        let binding = "0.0.0.0:9186".parse()?;
+        prometheus_exporter::start(binding)?;
+
+        let provider = Provider {
+            chain_tip: register_int_gauge!(
+                "chain_tip",
+                "the last detected tip of the chain (height)"
+            )?,
+            rollback_count: register_counter!(
+                "rollback_count",
+                "number of rollback events occurred"
+            )?,
+            source_current_slot: register_int_gauge!(
+                "source_current_slot",
+                "last slot processed by the source of the pipeline"
+            )?,
+            source_current_height: register_int_gauge!(
+                "source_current_height",
+                "last height (block #) processed by the source of the pipeline"
+            )?,
+            source_event_count: register_counter!(
+                "source_event_count",
+                "number of events processed by the source of the pipeline"
+            )?,
+            sink_current_slot: register_int_gauge!(
+                "sink_current_slot",
+                "last slot processed by the sink of the pipeline"
+            )?,
+            sink_event_count: register_counter!(
+                "sink_event_count",
+                "number of events processed by the sink of the pipeline"
+            )?,
+        };
+
+        Ok(provider)
+    }
+
+    pub(crate) fn on_source_event(&self, event: &Event) {
+        self.source_event_count.inc();
+
+        if let Some(slot) = &event.context.slot {
+            self.source_current_slot.set(*slot as i64);
+        }
+
+        if let Some(block) = &event.context.block_number {
+            self.source_current_height.set(*block as i64);
+        }
+
+        if matches!(event.data, EventData::RollBack { .. }) {
+            self.rollback_count.inc();
+        }
+    }
+
+    pub(crate) fn on_sink_event(&self, event: &Event) {
+        self.sink_event_count.inc();
+
+        if let Some(slot) = &event.context.slot {
+            self.sink_current_slot.set(*slot as i64);
+        }
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -27,6 +27,9 @@ pub mod throttle;
 pub(crate) mod bech32;
 pub(crate) mod time;
 
+#[cfg(feature = "metrics")]
+pub(crate) mod metrics;
+
 mod facade;
 
 pub(crate) trait SwallowResult {
@@ -105,6 +108,9 @@ pub struct Utils {
     pub(crate) time: Option<NaiveTime>,
     pub(crate) bech32: Bech32Provider,
     pub(crate) cursor: Option<cursor::Provider>,
+
+    #[cfg(feature = "metrics")]
+    pub(crate) metrics: metrics::Provider,
 }
 
 impl Utils {
@@ -115,6 +121,9 @@ impl Utils {
             bech32: Bech32Provider::new(Bech32Config::from_well_known(&well_known)),
             cursor,
             well_known,
+
+            #[cfg(feature = "metrics")]
+            metrics: metrics::Provider::start().unwrap(), //.expect("metric server started"),
         }
     }
 }


### PR DESCRIPTION
This PR introduces a `/metrics` endpoint that uses Prometheus format to expose metrics about the progress of the pipeline.

Each stage (source / sink) is responsible for notifying their progress as they process each event. This notifications are then aggregated via counters & gauges and exposed via HTTP using the well-known Prometheus encoding.

This PR includes the following metrics:

- `chain_tip`: the last detected tip of the chain (height)
- `rollback_count`: number of rollback events occurred
- `source_current_slot`: last slot processed by the source of the pipeline
- `source_current_height`: last height (block #) processed by the source of the pipeline
- `source_event_count`:  number of events processed by the source of the pipeline
- `sink_current_slot`: last slot processed by the sink of the pipeline
- `sink_event_count`: number of events processed by the sink of the pipeline