### PR TITLE
feat: Introduce AWS Lambda sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-lambda"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ce37ff9119422e2428461a1285f6c64d4a423d1ba268e93e915d6ab8f712fb0"
+dependencies = [
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-json",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http",
+ "tokio-stream",
+ "tower",
+]
+
+[[package]]
 name = "aws-sdk-sqs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1403,6 +1425,7 @@ name = "oura"
 version = "1.2.2"
 dependencies = [
  "aws-config",
+ "aws-sdk-lambda",
  "aws-sdk-sqs",
  "bech32",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ murmur3 = { version = "0.5.1", optional = true }
 # feature: aws
 aws-config = { version = "0.8.0", optional = true }
 aws-sdk-sqs = { version = "0.8.0", optional = true }
+aws-sdk-lambda = { version = "0.8.0", optional = true }
 
 # features: elasticsearch || aws
 tokio = { version = "1.17.0", optional = true, features = ["rt"] }

--- a/src/bin/oura/daemon.rs
+++ b/src/bin/oura/daemon.rs
@@ -36,6 +36,7 @@ use oura::sinks::kafka::Config as KafkaConfig;
 use oura::sinks::elastic::Config as ElasticConfig;
 
 #[cfg(feature = "aws")]
+use oura::sinks::aws_lambda::Config as AwsLambdaConfig;
 use oura::sinks::aws_sqs::Config as AwsSqsConfig;
 
 #[cfg(feature = "fingerprint")]
@@ -104,6 +105,7 @@ enum Sink {
     Elastic(ElasticConfig),
 
     #[cfg(feature = "aws")]
+    AwsLambda(AwsLambdaConfig),
     AwsSqs(AwsSqsConfig),
 }
 
@@ -126,6 +128,7 @@ fn bootstrap_sink(config: Sink, input: StageReceiver, utils: Arc<Utils>) -> Boot
         Sink::Elastic(c) => WithUtils::new(c, utils).bootstrap(input),
 
         #[cfg(feature = "aws")]
+        Sink::AwsLambda(c) => WithUtils::new(c, utils).bootstrap(input),
         Sink::AwsSqs(c) => WithUtils::new(c, utils).bootstrap(input),
     }
 }

--- a/src/sinks/aws_lambda/mod.rs
+++ b/src/sinks/aws_lambda/mod.rs
@@ -1,0 +1,4 @@
+mod run;
+mod setup;
+
+pub use setup::*;

--- a/src/sinks/aws_lambda/run.rs
+++ b/src/sinks/aws_lambda/run.rs
@@ -1,0 +1,54 @@
+use aws_sdk_lambda::{types::Blob, Client};
+use serde_json::json;
+use std::sync::Arc;
+
+use crate::{model::Event, pipelining::StageReceiver, utils::Utils, Error};
+
+async fn invoke_lambda_function(
+    client: Arc<Client>,
+    function_name: &str,
+    event: &Event,
+) -> Result<(), Error> {
+    let body = json!(event).to_string();
+
+    let req = client
+        .invoke()
+        .function_name(function_name)
+        .payload(Blob::new(body));
+
+    let res = req.send().await?;
+
+    log::trace!("Lambda invoke response: {:?}", res);
+
+    Ok(())
+}
+
+pub fn writer_loop(
+    input: StageReceiver,
+    client: Client,
+    function_name: &str,
+    utils: Arc<Utils>,
+) -> Result<(), Error> {
+    let client = Arc::new(client);
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .enable_io()
+        .build()?;
+
+    loop {
+        let event = input.recv().unwrap();
+
+        // notify the pipeline where we are
+        utils.track_sink_progress(&event);
+
+        let client = client.clone();
+
+        let result = rt.block_on(invoke_lambda_function(client, function_name, &event));
+
+        if let Err(err) = result {
+            log::error!("unrecoverable error invoking lambda funcion: {:?}", err);
+            break Err(err);
+        }
+    }
+}

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -15,4 +15,5 @@ pub mod kafka;
 pub mod elastic;
 
 #[cfg(feature = "aws")]
+pub mod aws_lambda;
 pub mod aws_sqs;


### PR DESCRIPTION
This PR introduces a new sink that sends each event as an invocation to an AWS Lambda function.

- it uses the existing feature flag names `aws` to enable the feature / dependencies
- the payload sent to the function is the JSON-encoded version of the on-chain event
- It uses the default credentials provider chain logic as common AWS libraries (env vars, .aws/credentials, EC2 context, etc)
- the built-in retry logic of the library is used for failed requests. Max retries is configurable at the sink-level.
