### PR TITLE
fixed tokio feature declaration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ aws-sdk-lambda = { version = "0.9.0", optional = true }
 aws-sdk-s3 = { version = "0.9.0", optional = true }
 
 # features: elasticsearch || aws
-tokio = { version = "1.17.0", optional = true, features = ["rt"] }
+tokio = { version = "1.17.0", optional = true, features = ["rt-multi-thread"] }
 
 # required for CI to complete successfully
 openssl = { version = "0.10", optional = true, features = ["vendored"] }


### PR DESCRIPTION
in token 1.17.0, the feature that enables `new` is now called `rt-multi-thread` rather than `rt` as per documentation, https://docs.rs/tokio/latest/tokio/runtime/struct.Runtime.html

Without this change, the following errors occur on compilation:

```
error[E0599]: no function or associated item named `new` found for struct `tokio::runtime::Runtime` in the current scope
  --> src/sinks/aws_sqs/setup.rs:26:51
   |
26 |         let aws_config = tokio::runtime::Runtime::new()?.block_on(
   |                                                   ^^^ function or associated item not found in `tokio::runtime::Runtime`

error[E0599]: no function or associated item named `new` found for struct `tokio::runtime::Runtime` in the current scope
  --> src/sinks/aws_lambda/setup.rs:24:51
   |
24 |         let aws_config = tokio::runtime::Runtime::new()?.block_on(
   |                                                   ^^^ function or associated item not found in `tokio::runtime::Runtime`

error[E0599]: no function or associated item named `new` found for struct `tokio::runtime::Runtime` in the current scope
  --> src/sinks/aws_s3/setup.rs:52:51
   |
52 |         let aws_config = tokio::runtime::Runtime::new()?.block_on(
   |                                                   ^^^ function or associated item not found in `tokio::runtime::Runtime`

For more information about this error, try `rustc --explain E0599`.
error: could not compile `oura` due to 3 previous errors
```