### PR TITLE
Allow to instanciate cursor::FileConfig and metrics::Config when using Oura as a library

### DIFF
--- a/src/utils/cursor.rs
+++ b/src/utils/cursor.rs
@@ -24,7 +24,7 @@ pub(crate) trait CanStore {
 /// Configuration for the file-based storage implementation
 #[derive(Debug, Deserialize)]
 pub struct FileConfig {
-    path: String,
+    pub path: String,
 }
 
 /// A cursor provider that uses the file system as the source for persistence

--- a/src/utils/metrics.rs
+++ b/src/utils/metrics.rs
@@ -9,10 +9,10 @@ use crate::{
     Error,
 };
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
-    binding: Option<String>,
-    endpoint: Option<String>,
+    pub binding: Option<String>,
+    pub endpoint: Option<String>,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
This is needed as far as I can tell to be able to use those config structs without deserialization when using Oura as a library.

- For an example of cursor::FileConfig instantiation, see https://github.com/SmaugPool/oura-script-sink/blob/244eac8a2bcd30088537b384ba50c25bba6aec75/src/setup.rs#L39
- For an example of metrics::Config instantiation, see https://github.com/SmaugPool/oura-script-sink/blob/244eac8a2bcd30088537b384ba50c25bba6aec75/src/args.rs#L63
- For an example of metrics::Config cloning, see https://github.com/SmaugPool/oura-script-sink/blob/244eac8a2bcd30088537b384ba50c25bba6aec75/src/setup.rs#L47

Of course adding some constructors is possible too if preferred.