### PR TITLE
feat: Add native scripts

### DIFF
--- a/src/mapper/map.rs
+++ b/src/mapper/map.rs
@@ -361,26 +361,6 @@ impl EventWriter {
             };
         }
 
-        // TODO: add witness set data to transaction
-        /*
-        if let Some(witness) = self.transaction_witness_sets.get(idx) {
-            let plutus_count = match &witness.plutus_script {
-                Some(scripts) => scripts.len(),
-                None => 0,
-            };
-
-            let native_count = match &witness.native_script {
-                Some(scripts) => scripts.len(),
-                None => 0,
-            };
-
-            let redeemer_count = match &witness.redeemer {
-                Some(redeemer) => redeemer.len(),
-                None => 0,
-            };
-        }
-        */
-
         if self.config.include_transaction_details {
             record.metadata = match aux_data {
                 Some(aux_data) => self.collect_metadata_records(aux_data)?.into(),

--- a/src/mapper/shelley.rs
+++ b/src/mapper/shelley.rs
@@ -232,6 +232,19 @@ impl EventWriter {
             self.append(EventData::BlockEnd(record))?;
         }
 
+        for witness in block.transaction_witness_sets.iter() {
+            if let Some(native) = &witness.native_script {
+                for script in native.iter() {
+                    self.append(self.to_native_script_event(script))?;
+                }
+            }
+            if let Some(plutus) = &witness.plutus_script {
+                for script in plutus.iter() {
+                    self.append(self.to_plutus_script_event(script))?;
+                }
+            }
+        }
+
         Ok(())
     }
 

--- a/src/mapper/shelley.rs
+++ b/src/mapper/shelley.rs
@@ -39,8 +39,10 @@ impl EventWriter {
                     self.crawl_metadata(metadata)?;
                 }
 
-                for _native in data.native_scripts.iter() {
-                    self.append(self.to_native_script_event())?;
+                if let Some(native) = &data.native_scripts {
+                    for script in native.iter() {
+                        self.append(self.to_native_script_event(script))?;
+                    }
                 }
 
                 if let Some(plutus) = &data.plutus_scripts {
@@ -58,8 +60,10 @@ impl EventWriter {
             } => {
                 self.crawl_metadata(transaction_metadata)?;
 
-                for _native in auxiliary_scripts.iter() {
-                    self.append(self.to_native_script_event())?;
+                if let Some(native) = &auxiliary_scripts {
+                    for script in native.iter() {
+                        self.append(self.to_native_script_event(script))?;
+                    }
                 }
             }
         }

--- a/src/model.rs
+++ b/src/model.rs
@@ -173,6 +173,32 @@ pub enum StakeCredential {
     Scripthash(String),
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, Display)]
+#[serde(rename_all = "camelCase")]
+#[serde(tag = "type")]
+pub enum NativeScript {
+    #[serde(rename_all = "camelCase")]
+    Sig {
+        key_hash: String,
+    },
+    All {
+        scripts: Vec<NativeScript>,
+    },
+    Any {
+        scripts: Vec<NativeScript>,
+    },
+    AtLeast {
+        required: u32,
+        scripts: Vec<NativeScript>,
+    },
+    Before {
+        slot: u64,
+    },
+    After {
+        slot: u64,
+    },
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct BlockRecord {
     pub era: Era,
@@ -215,7 +241,9 @@ pub enum EventData {
         tx_id: String,
         index: u64,
     },
-    NativeScript {},
+    NativeScript {
+        data: NativeScript,
+    },
     PlutusScript {
         data: String,
     },

--- a/src/model.rs
+++ b/src/model.rs
@@ -242,7 +242,8 @@ pub enum EventData {
         index: u64,
     },
     NativeScript {
-        data: NativeScript,
+        policy_id: String,
+        script: NativeScript,
     },
     PlutusScript {
         data: String,

--- a/src/sinks/terminal/format.rs
+++ b/src/sinks/terminal/format.rs
@@ -163,10 +163,10 @@ impl LogLine {
                 source,
                 max_width,
             },
-            EventData::NativeScript {} => LogLine {
+            EventData::NativeScript { data } => LogLine {
                 prefix: "NATIVE",
                 color: Color::White,
-                content: "{{ ... }}".to_string(),
+                content: format!("{{ {} }}", data),
                 source,
                 max_width,
             },

--- a/src/sinks/terminal/format.rs
+++ b/src/sinks/terminal/format.rs
@@ -163,10 +163,10 @@ impl LogLine {
                 source,
                 max_width,
             },
-            EventData::NativeScript { data } => LogLine {
+            EventData::NativeScript { policy_id, script } => LogLine {
                 prefix: "NATIVE",
                 color: Color::White,
-                content: format!("{{ {} }}", data),
+                content: format!("{{ policy_id: {}, script: {} }}", policy_id, script),
                 source,
                 max_width,
             },


### PR DESCRIPTION
This is used by https://github.com/SmaugPool/oura-script-sink to make all minting policies available on pool.pm.

I'm not sure if we would like to be able to distinguish scripts coming from witnesses from those coming from auxiliary data.
For now this is not the case.