### PR TITLE
Add `datum_hash` to `TxOutput` events

### DIFF
--- a/src/mapper/byron.rs
+++ b/src/mapper/byron.rs
@@ -45,6 +45,7 @@ impl EventWriter {
             address: source.address.to_addr_string()?,
             amount: source.amount,
             assets: None,
+            datum_hash: None,
         })
     }
 

--- a/src/mapper/map.rs
+++ b/src/mapper/map.rs
@@ -171,6 +171,7 @@ impl EventWriter {
                 .encode_address(output.address.as_slice())?,
             amount: get_tx_output_coin_value(&output.amount),
             assets: self.collect_asset_records(&output.amount).into(),
+            datum_hash: output.datum_hash.map(|hash| hash.to_string()),
         })
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -122,6 +122,7 @@ pub struct TxOutputRecord {
     pub address: String,
     pub amount: u64,
     pub assets: Option<Vec<OutputAssetRecord>>,
+    pub datum_hash: Option<String>,
 }
 
 impl From<TxOutputRecord> for EventData {


### PR DESCRIPTION
This is especially useful after addition of `PlutusDatum` events.
Not sure how to match datum values to outputs without this.

It's a new field, so likely to break code parsing JSON events -- should I add a note about this somewhere?
Tested with `dump` and `webhook` sinks.