### PR TITLE
pool registration metadata hash extract

### DIFF
--- a/src/mapper/map.rs
+++ b/src/mapper/map.rs
@@ -302,6 +302,7 @@ impl EventWriter {
                 pool_owners: pool_owners.iter().map(|p| p.to_hex()).collect(),
                 relays: relays.iter().map(relay_to_string).collect(),
                 pool_metadata: pool_metadata.as_ref().map(|m| m.url.clone()),
+                pool_metadata_hash: pool_metadata.as_ref().map(|m| m.hash.clone().to_hex())
             },
             Certificate::PoolRetirement(pool, epoch) => EventData::PoolRetirement {
                 pool: pool.to_hex(),

--- a/src/model.rs
+++ b/src/model.rs
@@ -330,6 +330,7 @@ pub enum EventData {
         pool_owners: Vec<String>,
         relays: Vec<String>,
         pool_metadata: Option<String>,
+        pool_metadata_hash: Option<String>,
     },
     PoolRetirement {
         pool: String,

--- a/src/sinks/terminal/format.rs
+++ b/src/sinks/terminal/format.rs
@@ -248,6 +248,7 @@ impl LogLine {
                 pool_owners: _,
                 relays: _,
                 pool_metadata,
+                pool_metadata_hash: _,
             } => LogLine {
                 prefix: "POOL+",
                 color: Color::Magenta,


### PR DESCRIPTION
Pool registration metadata needs to be validated against the on chain metadata hash.  This PR will extract the hash as well from the certificate to allow downstream processing and validation of the metadata at that url.
