### PR TITLE
docs: Add redis streams documentation to book index

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -26,6 +26,7 @@
     - [AWS SQS](./sinks/aws_sqs.md)
     - [AWS Lambda](./sinks/aws_lambda.md)
     - [AWS S3](./sinks/aws_s3.md)
+    - [Redis Streams](./sinks/redis_streams.md)
 - [Reference](reference/README.md)
     - [Data Dictionary](./reference/data_dictionary.md)
 - [Advanced Features](./advanced/README.md)

--- a/book/src/sinks/README.md
+++ b/book/src/sinks/README.md
@@ -16,5 +16,6 @@ These are the existing sinks that are included as part the main _Oura_ codebase:
 - [AWS S3](aws_s3.md): a sink that saves the CBOR content of the blocks as an AWS S3 object.
 - [GCP PubSub](gcp_pubsub.md): a sink that sends each event as a message to a google cloud PubSub topic.
 - [GCP CloudFunction](gcp_cloudfunction.md): a sink that sends each event as JSON to a Cloud Function via HTTP.
+- [Redis Streams](redis_streams.md): a sink that sends each event into a Redis stream.
 
 New sinks are being developed, information will be added in this documentation to reflect the updated list. Contributions and feature request are welcome in our [Github Repo](https://github.com/txpipe/oura).


### PR DESCRIPTION
The Redis Streams sink documentation was missing from the book index.

This fixes that.