### PR TITLE
chore: add all features flag in from source docs

### DIFF
--- a/book/src/installation/from_source.md
+++ b/book/src/installation/from_source.md
@@ -11,5 +11,5 @@ The following instructions show how to build and install _Oura_ from source code
 ```
 git clone git@github.com:txpipe/oura.git
 cd oura
-cargo install --path .
+cargo install --all-features --path .
 ```


### PR DESCRIPTION
I noticed a few times people end up wondering why the sink in their config isn't available after building from source.

Usually I tell them to use this flag and their problem goes away.

I added the flag to the install command to avoid this confusion in the future.