### PR TITLE
Logging: N2N error logged in N2C #401

### DIFF
--- a/src/sources/n2c/run.rs
+++ b/src/sources/n2c/run.rs
@@ -231,7 +231,7 @@ pub fn do_chainsync(
         || match do_chainsync_attempt(config, utils.clone(), &output_tx) {
             Ok(()) => Ok(()),
             Err(AttemptError::Other(msg)) => {
-                log::error!("N2N error: {}", msg);
+                log::error!("N2C error: {}", msg);
                 log::warn!("unrecoverable error performing chainsync, will exit");
                 Ok(())
             }


### PR DESCRIPTION
Fixed the typo in the error message logged in N2C. 

Fixes https://github.com/txpipe/oura/issues/401