### PR TITLE
Exposed Cbor Datum encoded in hex

### DIFF
--- a/src/mapper/byron.rs
+++ b/src/mapper/byron.rs
@@ -45,6 +45,7 @@ impl EventWriter {
             amount: source.amount,
             assets: None,
             datum_hash: None,
+            datum_cbor: None
         })
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -125,6 +125,7 @@ pub struct TxOutputRecord {
     pub amount: u64,
     pub assets: Option<Vec<OutputAssetRecord>>,
     pub datum_hash: Option<String>,
+    pub datum_cbor: Option<String>,
 }
 
 impl From<TxOutputRecord> for EventData {


### PR DESCRIPTION
**Example Transaction Output (mainnet)**

```
TxHash : 25b8f78de7a1c2a3f76847243026b802a6bc9bfdb94f16e25af80d61e5c6e21d
Address: addr1zxgx3far7qygq0k6epa0zcvcvrevmn0ypsnfsue94nsn3tvpw288a4x0xf8pxgcntelxmyclq83s0ykeehchz2wtspks905plm 
Amount: 1719690 
Assets: [
  {
    policy: "2a89138bffea582b621a747015c1c90259d6b4751eeccaa39c4a7dfb",
    asset: "467572696e31303538",
    asset_ascii: "Furin1058",
    amount: 1
  }
] 
Datum Hash: b7c6656e143cfe98b9e9953e94fd94f14b9b6f954c56223e533841b60768eb15 
Datum Cbor: d8799f581c9068a7a3f008803edac87af1619860f2cdcde40c26987325ace138ad9fd8799fd8799fd8799f581cc2c1fa66dcf85be519aa486eba967e16ea93abbe26fc472ad19c46b0ffd8799fd8799fd8799f581cecc17a0480
```