### PR TITLE
Dockerfile uses buster debian, which is end of life #519

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust:1-buster as builder-arm64
+FROM --platform=linux/amd64 rust:1-bullseye as builder-arm64
 
 RUN apt update && apt upgrade -y
 RUN apt install -y g++-arm-linux-gnueabihf libc6-dev-armhf-cross
@@ -14,7 +14,7 @@ ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
 
 
 
-FROM --platform=linux/amd64 rust:1-buster as builder-amd64
+FROM --platform=linux/amd64 rust:1-bullseye as builder-amd64
 
 ENV RUST_TARGET=x86_64-unknown-linux-gnu
 
@@ -30,7 +30,7 @@ RUN cargo build --release --target ${RUST_TARGET} --all-features
 
 RUN cp /code/target/${RUST_TARGET}/release/oura /oura
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
 - Updated the Oura Dockerfile to be using bullseye (Debian 11), instead of buster (Debian 10).

Fixes: https://github.com/txpipe/oura/issues/519