### PR TITLE
fix: Use correct bytes for Byron addresses

### DIFF
--- a/src/mapper/byron.rs
+++ b/src/mapper/byron.rs
@@ -41,7 +41,12 @@ impl EventWriter {
     }
 
     fn to_byron_output_record(&self, source: &byron::TxOut) -> Result<TxOutputRecord, Error> {
-        let address = pallas::ledger::addresses::Address::from_bytes(&source.address.payload)?;
+        let address: pallas::ledger::addresses::Address =
+            pallas::ledger::addresses::ByronAddress::new(
+                &source.address.payload.0,
+                source.address.crc,
+            )
+            .into();
 
         Ok(TxOutputRecord {
             address: address.to_string(),


### PR DESCRIPTION
We were using the wrong bytes to parse Byron addresses, which resulted on an error trying to crawl Byron transactions. This PR fixes the issue by using the correct data field.