### PR TITLE
Add vkey filtering

### DIFF
--- a/src/filters/selection.rs
+++ b/src/filters/selection.rs
@@ -23,6 +23,7 @@ pub enum Predicate {
     AddressEquals(String),
     MetadataLabelEquals(String),
     MetadataAnySubLabelEquals(String),
+    VKeyWitnessesIncludes(String),
     Not(Box<Predicate>),
     AnyOf(Vec<Predicate>),
     AllOf(Vec<Predicate>),
@@ -150,6 +151,14 @@ fn metadata_any_sub_label_matches(event: &Event, sub_label: &str) -> bool {
     }
 }
 
+#[inline]
+fn vkey_witnesses_matches(event: &Event, witness: &str) -> bool {
+    match &event.data {
+        EventData::VKeyWitness(x) => x.vkey_hex == witness,
+        _ => false 
+    }
+}
+
 impl Predicate {
     #![allow(deprecated)]
     fn event_matches(&self, event: &Event) -> bool {
@@ -169,6 +178,7 @@ impl Predicate {
             }
             Predicate::MetadataLabelEquals(x) => metadata_label_matches(event, x),
             Predicate::MetadataAnySubLabelEquals(x) => metadata_any_sub_label_matches(event, x),
+            Predicate::VKeyWitnessesIncludes(x) => vkey_witnesses_matches(event, x),
             Predicate::Not(x) => !x.event_matches(event),
             Predicate::AnyOf(x) => x.iter().any(|c| c.event_matches(event)),
             Predicate::AllOf(x) => x.iter().all(|c| c.event_matches(event)),

--- a/src/filters/selection.rs
+++ b/src/filters/selection.rs
@@ -166,9 +166,13 @@ fn vkey_witnesses_matches(event: &Event, witness: &str) -> bool {
 }
 
 #[inline]
-fn native_scripts_matches(event: &Event, id: &str) -> bool {
+fn native_scripts_matches(event: &Event, policy_id: &str) -> bool {
     match &event.data {
-        EventData::NativeScript { policy_id, .. } => policy_id == id,
+        EventData::NativeWitness(x) => x.policy_id == policy_id,
+        EventData::Transaction(x) => 
+            x.native_witnesses.as_ref()
+                .map(|vs| vs.iter().any(|v| v.policy_id == policy_id))
+                .unwrap_or(false),
         _ => false 
     }
 }
@@ -176,7 +180,11 @@ fn native_scripts_matches(event: &Event, id: &str) -> bool {
 #[inline]
 fn plutus_scripts_matches(event: &Event, script_hash: &str) -> bool {
     match &event.data {
-        EventData::PlutusScript { hash, .. } => hash == script_hash,
+        EventData::PlutusWitness(x) => x.script_hash == script_hash,
+        EventData::Transaction(x) => 
+            x.plutus_witnesses.as_ref()
+                .map(|vs| vs.iter().any(|v| v.script_hash == script_hash))
+                .unwrap_or(false),
         _ => false 
     }
 }


### PR DESCRIPTION
For one of our projects at MLabs, we'd like the ability to filter based off the signers, the policy ids, and the plutus script hashes as a way to help reduce the amount of data we need to sort through. This PR implements that.