### PR TITLE
add ordering key for pubsub

### DIFF
--- a/src/sinks/gcp_pubsub/run.rs
+++ b/src/sinks/gcp_pubsub/run.rs
@@ -18,12 +18,12 @@ use crate::{
 async fn send_pubsub_msg(
     publisher: &Publisher,
     event: &Event,
-    ordering_key: String,
+    ordering_key: &str,
 ) -> Result<(), crate::Error> {
     let body = json!(event).to_string();
     let msg = PubsubMessage {
         data: body.into(),
-        ordering_key,
+        ordering_key: ordering_key.into(),
         ..Default::default()
     };
 
@@ -42,7 +42,7 @@ pub fn writer_loop(
     topic_name: &str,
     error_policy: &ErrorPolicy,
     retry_policy: &retry::Policy,
-    ordering_key: &String,
+    ordering_key: &str,
     utils: Arc<Utils>,
 ) -> Result<(), crate::Error> {
     let rt = tokio::runtime::Builder::new_current_thread()
@@ -58,7 +58,7 @@ pub fn writer_loop(
 
     for event in input.iter() {
         let result = retry::retry_operation(
-            || rt.block_on(send_pubsub_msg(&publisher, &event, ordering_key.clone())),
+            || rt.block_on(send_pubsub_msg(&publisher, &event, ordering_key)),
             retry_policy,
         );
 

--- a/src/sinks/gcp_pubsub/run.rs
+++ b/src/sinks/gcp_pubsub/run.rs
@@ -15,10 +15,15 @@ use crate::{
     utils::{retry, Utils},
 };
 
-async fn send_pubsub_msg(publisher: &Publisher, event: &Event) -> Result<(), crate::Error> {
+async fn send_pubsub_msg(
+    publisher: &Publisher,
+    event: &Event,
+    ordering_key: String,
+) -> Result<(), crate::Error> {
     let body = json!(event).to_string();
     let msg = PubsubMessage {
         data: body.into(),
+        ordering_key,
         ..Default::default()
     };
 
@@ -37,6 +42,7 @@ pub fn writer_loop(
     topic_name: &str,
     error_policy: &ErrorPolicy,
     retry_policy: &retry::Policy,
+    ordering_key: &String,
     utils: Arc<Utils>,
 ) -> Result<(), crate::Error> {
     let rt = tokio::runtime::Builder::new_current_thread()
@@ -52,7 +58,7 @@ pub fn writer_loop(
 
     for event in input.iter() {
         let result = retry::retry_operation(
-            || rt.block_on(send_pubsub_msg(&publisher, &event)),
+            || rt.block_on(send_pubsub_msg(&publisher, &event, ordering_key.clone())),
             retry_policy,
         );
 

--- a/src/sinks/gcp_pubsub/setup.rs
+++ b/src/sinks/gcp_pubsub/setup.rs
@@ -34,8 +34,7 @@ impl SinkProvider for WithUtils<Config> {
         let ordering_key = self
             .inner
             .ordering_key
-            .as_ref()
-            .cloned()
+            .to_owned()
             .unwrap_or_default();
 
         let utils = self.utils.clone();

--- a/src/sinks/gcp_pubsub/setup.rs
+++ b/src/sinks/gcp_pubsub/setup.rs
@@ -13,6 +13,7 @@ pub struct Config {
     pub topic: String,
     pub error_policy: Option<ErrorPolicy>,
     pub retry_policy: Option<retry::Policy>,
+    pub ordering_key: Option<String>,
 
     #[warn(deprecated)]
     pub credentials: Option<String>,
@@ -30,12 +31,25 @@ impl SinkProvider for WithUtils<Config> {
             .unwrap_or(ErrorPolicy::Exit);
 
         let retry_policy = self.inner.retry_policy.unwrap_or_default();
+        let ordering_key = self
+            .inner
+            .ordering_key
+            .as_ref()
+            .cloned()
+            .unwrap_or_default();
 
         let utils = self.utils.clone();
 
         let handle = std::thread::spawn(move || {
-            writer_loop(input, &topic_name, &error_policy, &retry_policy, utils)
-                .expect("writer loop failed");
+            writer_loop(
+                input,
+                &topic_name,
+                &error_policy,
+                &retry_policy,
+                &ordering_key,
+                utils,
+            )
+            .expect("writer loop failed");
         });
 
         Ok(handle)


### PR DESCRIPTION
Solves #710. 

Adding the option to set an ordering key when using pubsub. This should help in ensuring sequential/ordered processing on pubsub side

