### PR TITLE
Update OS version to Debian 12 (bookworm)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust:1-bullseye as builder-arm64
+FROM --platform=linux/amd64 rust:1-bookworm as builder-arm64
 
 RUN apt update && apt upgrade -y
 RUN apt install -y g++-arm-linux-gnueabihf libc6-dev-armhf-cross
@@ -14,7 +14,7 @@ ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
 
 
 
-FROM --platform=linux/amd64 rust:1-bullseye as builder-amd64
+FROM --platform=linux/amd64 rust:1-bookworm as builder-amd64
 
 ENV RUST_TARGET=x86_64-unknown-linux-gnu
 
@@ -30,7 +30,7 @@ RUN cargo build --release --target ${RUST_TARGET} --all-features
 
 RUN cp /code/target/${RUST_TARGET}/release/oura /oura
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
**Problem:**
- Debian 11 (bullseye) is about to be transitioned to LTS support (August 14th, 2024), which is limited compared to the regular support for stable releases.

For further details please see:
- https://www.debian.org/releases/bullseye/

**Solution:**
- Update the OS version used in the Oura Docker container to Debian 12 (bookworm), so we could profit from higher support level and faster security patching process.