### PR TITLE
fix: fully expose source and sink configs

### DIFF
--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -3,13 +3,13 @@ use serde::Deserialize;
 
 use crate::framework::*;
 
-mod assert;
-mod common;
-mod file_rotate;
-mod noop;
-mod stdout;
-mod terminal;
-mod webhook;
+pub mod assert;
+pub mod common;
+pub mod file_rotate;
+pub mod noop;
+pub mod stdout;
+pub mod terminal;
+pub mod webhook;
 
 #[cfg(feature = "rabbitmq")]
 mod rabbitmq;

--- a/src/sources/n2c.rs
+++ b/src/sources/n2c.rs
@@ -195,7 +195,7 @@ impl gasket::framework::Worker<Stage> for Worker {
 
 #[derive(Deserialize)]
 pub struct Config {
-    socket_path: PathBuf,
+    pub socket_path: PathBuf,
 }
 
 impl Config {

--- a/src/sources/n2n.rs
+++ b/src/sources/n2n.rs
@@ -220,7 +220,7 @@ impl gasket::framework::Worker<Stage> for Worker {
 
 #[derive(Deserialize)]
 pub struct Config {
-    peers: Vec<String>,
+    pub peers: Vec<String>,
 }
 
 impl Config {


### PR DESCRIPTION
This is needed when using Oura as a library.