### PR TITLE
Factor out `run_daemon` and move to library

### DIFF
--- a/src/bin/oura/main.rs
+++ b/src/bin/oura/main.rs
@@ -2,21 +2,21 @@ use clap::Parser;
 use std::process;
 
 mod console;
-mod daemon;
+mod run_daemon;
 
 #[derive(Parser)]
 #[clap(name = "Oura")]
 #[clap(bin_name = "oura")]
 #[clap(author, version, about, long_about = None)]
 enum Oura {
-    Daemon(daemon::Args),
+    Daemon(run_daemon::Args),
 }
 
 fn main() {
     let args = Oura::parse();
 
     let result = match args {
-        Oura::Daemon(x) => daemon::run(&x),
+        Oura::Daemon(x) => run_daemon::run(&x),
     };
 
     if let Err(err) = &result {

--- a/src/bin/oura/run_daemon.rs
+++ b/src/bin/oura/run_daemon.rs
@@ -1,0 +1,85 @@
+use gasket::daemon::Daemon;
+use oura::framework::*;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tracing::info;
+use oura::daemon::{run_daemon, ConfigRoot, MetricsConfig};
+
+use crate::console;
+
+fn setup_tracing() {
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::FmtSubscriber::builder()
+            .with_max_level(tracing::Level::DEBUG)
+            .finish(),
+    )
+    .unwrap();
+}
+
+async fn serve_prometheus(
+    daemon: Arc<Daemon>,
+    metrics: Option<MetricsConfig>,
+) -> Result<(), Error> {
+    if let Some(metrics) = metrics {
+        info!("starting metrics exporter");
+        let runtime = daemon.clone();
+
+        let addr: SocketAddr = metrics
+            .address
+            .as_deref()
+            .unwrap_or("0.0.0.0:9186")
+            .parse()
+            .map_err(Error::parse)?;
+
+        gasket_prometheus::serve(addr, runtime).await;
+    }
+
+    Ok(())
+}
+
+pub fn run(args: &Args) -> Result<(), Error> {
+    if !args.tui {
+        setup_tracing();
+    }
+
+    let config = ConfigRoot::new(&args.config).map_err(Error::config)?;
+    let metrics = config.metrics.clone();
+
+    let daemon = run_daemon(config)?;
+
+    info!("oura is running");
+
+    let daemon = Arc::new(daemon);
+
+    let tokio_rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .unwrap();
+
+    let prometheus = tokio_rt.spawn(serve_prometheus(daemon.clone(), metrics));
+    let tui = tokio_rt.spawn(console::render(daemon.clone(), args.tui));
+
+    daemon.block();
+
+    info!("oura is stopping");
+
+    daemon.teardown();
+    prometheus.abort();
+    tui.abort();
+
+    Ok(())
+}
+
+
+#[derive(clap::Args)]
+#[clap(author, version, about, long_about = None)]
+pub struct Args {
+    /// config file to load by the daemon
+    #[clap(long, value_parser)]
+    config: Option<std::path::PathBuf>,
+
+    /// display the terminal UI
+    #[clap(long, action)]
+    tui: bool,
+}

--- a/src/bin/oura/run_daemon.rs
+++ b/src/bin/oura/run_daemon.rs
@@ -71,7 +71,6 @@ pub fn run(args: &Args) -> Result<(), Error> {
     Ok(())
 }
 
-
 #[derive(clap::Args)]
 #[clap(author, version, about, long_about = None)]
 pub struct Args {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,4 @@ pub mod filters;
 pub mod framework;
 pub mod sinks;
 pub mod sources;
+pub mod daemon;


### PR DESCRIPTION
To make it easier to test `oura daemon` in #823, we found it practical to split

```rust
// src/bin/oura/daemon.rs
pub fn run(args: &Args) -> Result<(), Error>
```

into:

```rust
// src/daemon/mod.rs
pub fn run_daemon(config: ConfigRoot) -> Result<Daemon, Error>

// src/bin/oura/run_daemon.rs
pub fn run(args: &Args) -> Result<(), Error>
```

to be able to start the daemon with having to first write a temporary config file to disk.