### PR TITLE
fix: bump pallas + utxorpc to utxorpc-spec 0.19 (#921)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -207,7 +207,7 @@ dependencies = [
  "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -1078,18 +1078,19 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bech32"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
+checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
 name = "binary-layout"
-version = "3.3.0"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5845e3504cf59b9588fff324710f27ee519515b8a8a9f1207042da9a9e64f819"
+checksum = "66c7e8da2156abef3421f6226ef339ade8c0d157ec50932d5e624f1c6a5127b4"
 dependencies = [
  "doc-comment",
  "paste",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1113,34 +1114,6 @@ dependencies = [
  "shlex",
  "syn 2.0.106",
  "which",
-]
-
-[[package]]
-name = "bip39"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d193de1f7487df1914d3a568b772458861d33f9c54249612cc2893d6915054"
-dependencies = [
- "bitcoin_hashes",
- "rand_core 0.6.4",
- "serde",
- "unicode-normalization",
-]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
-dependencies = [
- "bitcoin-internals",
- "hex-conservative",
 ]
 
 [[package]]
@@ -1276,9 +1249,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytes-utils"
@@ -1420,6 +1393,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,7 +1542,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1689,6 +1673,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1998,7 +1991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -2299,15 +2292,6 @@ dependencies = [
  "pkcs8 0.10.2",
  "serde",
  "signature 2.2.0",
-]
-
-[[package]]
-name = "ed25519-bip32"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb588f93c0d91b2f668849fd6d030cddb0b2e31f105963be189da5acdf492a21"
-dependencies = [
- "cryptoxide",
 ]
 
 [[package]]
@@ -2952,8 +2936,22 @@ checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -3223,12 +3221,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hex-conservative"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
-
-[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3484,7 +3476,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -4207,7 +4199,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0452a60c1863c1f50b5f77cd295e8d2786849f35883f0b9e18e7e6e1b5691b0"
 dependencies = [
  "half",
- "minicbor-derive",
+ "minicbor-derive 0.15.3",
+]
+
+[[package]]
+name = "minicbor"
+version = "0.26.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a309f581ade7597820083bc275075c4c6986e57e53f8d26f88507cfefc8c987"
+dependencies = [
+ "half",
+ "minicbor-derive 0.16.2",
 ]
 
 [[package]]
@@ -4215,6 +4217,17 @@ name = "minicbor-derive"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd2209fff77f705b00c737016a48e73733d7fbccb8b007194db148f03561fb70"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9882ef5c56df184b8ffc107fc6c61e33ee3a654b021961d790a78571bb9d67a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4292,7 +4305,7 @@ dependencies = [
  "slog",
  "strum 0.27.2",
  "tar",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "uuid",
  "zstd",
@@ -4306,7 +4319,7 @@ checksum = "0253a5237371e7795495e740766f49d6da85e736127239bee067020ac0f0a629"
 dependencies = [
  "anyhow",
  "async-trait",
- "bech32 0.11.0",
+ "bech32 0.11.1",
  "blake2 0.10.6",
  "chrono",
  "ciborium",
@@ -4335,7 +4348,7 @@ dependencies = [
  "sha2",
  "slog",
  "strum 0.27.2",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "typetag",
  "walkdir",
@@ -4358,7 +4371,7 @@ dependencies = [
  "rayon",
  "rug",
  "serde",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4731,7 +4744,7 @@ dependencies = [
  "rc2",
  "sha1",
  "sha2",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "x509-parser",
 ]
 
@@ -4748,20 +4761,21 @@ dependencies = [
 
 [[package]]
 name = "pallas"
-version = "0.35.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38beab59b184e78e53ffe12b80db92de0ae77aaf6549a7a02a116ef232c57c32"
+checksum = "48773d1214fa3e3a4d79f08eac74e3bfdad67c1e441c5817696cb42f34cbf138"
 dependencies = [
- "pallas-addresses 0.35.1",
- "pallas-codec 0.35.1",
+ "pallas-addresses 1.1.0",
+ "pallas-codec 1.1.0",
  "pallas-configs",
- "pallas-crypto 0.35.1",
+ "pallas-crypto 1.1.0",
  "pallas-hardano",
- "pallas-network 0.35.1",
- "pallas-primitives 0.35.1",
- "pallas-traverse 0.35.1",
+ "pallas-network 1.1.0",
+ "pallas-primitives 1.1.0",
+ "pallas-traverse 1.1.0",
  "pallas-txbuilder",
  "pallas-utxorpc",
+ "pallas-validate",
 ]
 
 [[package]]
@@ -4782,34 +4796,18 @@ dependencies = [
 
 [[package]]
 name = "pallas-addresses"
-version = "0.35.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b562be9b1f713ac8935bd61197c2d5f7b054574bb45081545866df99428d8176"
+checksum = "1c3988277ebfa1c7efde42fb2382deebe80aa3f321fd5d2e87ef5ee9dfc7b685"
 dependencies = [
  "base58",
- "bech32 0.9.1",
+ "bech32 0.11.1",
  "crc",
  "cryptoxide",
  "hex",
- "pallas-codec 0.35.1",
- "pallas-crypto 0.35.1",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "pallas-applying"
-version = "0.35.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fa7a0b04aa3cc38ab298fd00759ccaa3e1a82c5db9643dadeb5b08b5fe0126"
-dependencies = [
- "chrono",
- "hex",
- "pallas-addresses 0.35.1",
- "pallas-codec 0.35.1",
- "pallas-crypto 0.35.1",
- "pallas-primitives 0.35.1",
- "pallas-traverse 0.35.1",
- "rand 0.8.5",
+ "pallas-codec 1.1.0",
+ "pallas-crypto 1.1.0",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4819,36 +4817,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e344b3e39ca3bd79bb7547b65b980869c3c377a00c48ece70430f4611c32a18b"
 dependencies = [
  "hex",
- "minicbor",
+ "minicbor 0.25.1",
  "serde",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "pallas-codec"
-version = "0.35.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afff0c114bc5ff0e5bf95b6b151a664da57c259ab266bcff6587faad91a064d2"
+checksum = "8dc8ec5e664aa50ae954c3e5d7d4887ab2b21cdf016a10422c0b2c97e7558686"
 dependencies = [
  "hex",
- "minicbor",
+ "minicbor 0.26.5",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "pallas-configs"
-version = "0.35.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f7bf49f3fe6f7c840af37ccc9c3c08675766d2fd8f3f3e62d6c120ccd31c95"
+checksum = "f96807d2c3418d53031ca80a29c778951efa572f5f4aff85265ff6a64dfebe19"
 dependencies = [
  "base64 0.22.1",
- "hex",
  "num-rational",
- "pallas-addresses 0.35.1",
- "pallas-codec 0.35.1",
- "pallas-crypto 0.35.1",
- "pallas-primitives 0.35.1",
+ "pallas-addresses 1.1.0",
+ "pallas-crypto 1.1.0",
+ "pallas-primitives 1.1.0",
  "serde",
  "serde_json",
  "serde_with 3.14.0",
@@ -4871,30 +4867,36 @@ dependencies = [
 
 [[package]]
 name = "pallas-crypto"
-version = "0.35.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e25299b6992b179144464e410680cf096919f43cf97f9a6fea2f7be5e1cadd"
+checksum = "c62f08aa8af671cd4ebb41081b6ea857077b0587ffde16a640bd8f2af0e86b5d"
 dependencies = [
  "cryptoxide",
  "hex",
- "pallas-codec 0.35.1",
- "rand_core 0.6.4",
+ "pallas-codec 1.1.0",
+ "rand_core 0.10.1",
  "serde",
- "thiserror 1.0.69",
- "zeroize",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "pallas-hardano"
-version = "0.35.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807aa18cdf029c537deedc5ea0aa956258f5bc0c2e482c3102a9752612cd73e5"
+checksum = "e73931aa6bb8a6adfd8f37fe991a7983b6024f3231fddbe488b56db6ab189170"
 dependencies = [
  "binary-layout",
- "pallas-network 0.35.1",
- "pallas-traverse 0.35.1",
+ "hex",
+ "pallas-addresses 1.1.0",
+ "pallas-codec 1.1.0",
+ "pallas-crypto 1.1.0",
+ "pallas-network 1.1.0",
+ "pallas-traverse 1.1.0",
+ "serde",
+ "serde_json",
+ "serde_with 3.14.0",
  "tap",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -4918,19 +4920,18 @@ dependencies = [
 
 [[package]]
 name = "pallas-network"
-version = "0.35.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4146073d190abd9b752768966b68bef527e21aa16f4555d35a7d7cd43c91a24"
+checksum = "aad130ec8195018a8308f63130c5bf49abdc5531efe7431257fb0278336adaa6"
 dependencies = [
  "byteorder",
  "hex",
- "itertools 0.13.0",
- "pallas-codec 0.35.1",
- "pallas-crypto 0.35.1",
- "rand 0.8.5",
- "serde",
- "socket2 0.5.10",
- "thiserror 1.0.69",
+ "itertools 0.14.0",
+ "pallas-codec 1.1.0",
+ "pallas-crypto 1.1.0",
+ "rand 0.10.1",
+ "socket2 0.6.4",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -4953,16 +4954,13 @@ dependencies = [
 
 [[package]]
 name = "pallas-primitives"
-version = "0.35.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "857f6908501bcb6f794f2c81674eb0f69414e66399739bbd808aa178c17c2001"
+checksum = "cac94485435820b8765c87e9f2c5167ba4729f56117a669aba5a3e4c4f522545"
 dependencies = [
- "base58",
- "bech32 0.9.1",
  "hex",
- "log",
- "pallas-codec 0.35.1",
- "pallas-crypto 0.35.1",
+ "pallas-codec 1.1.0",
+ "pallas-crypto 1.1.0",
  "serde",
  "serde_json",
 ]
@@ -4986,67 +4984,70 @@ dependencies = [
 
 [[package]]
 name = "pallas-traverse"
-version = "0.35.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88753e28c456fe38c6a4d84ff8847a25bf564753c255a1d6d211d9fd6a42380e"
+checksum = "f917f26d63e1e014d5ea1fc734307ea3a688b74991fe2eddee64a73c3ab15aaf"
 dependencies = [
  "hex",
- "itertools 0.13.0",
- "pallas-addresses 0.35.1",
- "pallas-codec 0.35.1",
- "pallas-crypto 0.35.1",
- "pallas-primitives 0.35.1",
+ "itertools 0.14.0",
+ "pallas-addresses 1.1.0",
+ "pallas-codec 1.1.0",
+ "pallas-crypto 1.1.0",
+ "pallas-primitives 1.1.0",
  "paste",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "pallas-txbuilder"
-version = "0.35.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a667c33a45893cf14f27637292965370eb342568399a84137290b78a3091e74"
+checksum = "7b97e466b38c75a8725fab9ca619c17cb66c09ab356f8e85bfe041f5e3c34e49"
 dependencies = [
  "hex",
- "pallas-addresses 0.35.1",
- "pallas-codec 0.35.1",
- "pallas-crypto 0.35.1",
- "pallas-primitives 0.35.1",
- "pallas-traverse 0.35.1",
- "pallas-wallet",
+ "pallas-addresses 1.1.0",
+ "pallas-codec 1.1.0",
+ "pallas-crypto 1.1.0",
+ "pallas-primitives 1.1.0",
+ "pallas-traverse 1.1.0",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "pallas-utxorpc"
-version = "0.35.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d27ead19b99aea07abe1014098ae7e4ff47c0fe3ff0eec33f2f582af3c84d12b"
+checksum = "c59b43ca1414603cc6d011c854f49afe3afbda60f39f90dae6f2879883cc84aa"
 dependencies = [
- "pallas-applying",
- "pallas-codec 0.35.1",
- "pallas-crypto 0.35.1",
- "pallas-primitives 0.35.1",
- "pallas-traverse 0.35.1",
+ "pallas-codec 1.1.0",
+ "pallas-crypto 1.1.0",
+ "pallas-primitives 1.1.0",
+ "pallas-traverse 1.1.0",
+ "pallas-validate",
  "prost-types",
  "utxorpc-spec",
 ]
 
 [[package]]
-name = "pallas-wallet"
-version = "0.35.1"
+name = "pallas-validate"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d1764dc6bddd0ca8d5f2e935c7ee2c7e312776dde1d5506a4adb40f3767c5d"
+checksum = "881df106d3b758f62105245b5e27b98766f1dc64f309115c60a8700ba85c3ea6"
 dependencies = [
- "bech32 0.9.1",
- "bip39",
- "cryptoxide",
- "ed25519-bip32",
- "pallas-crypto 0.35.1",
- "rand 0.8.5",
- "thiserror 1.0.69",
+ "chrono",
+ "hex",
+ "itertools 0.14.0",
+ "pallas-addresses 1.1.0",
+ "pallas-codec 1.1.0",
+ "pallas-crypto 1.1.0",
+ "pallas-primitives 1.1.0",
+ "pallas-traverse 1.1.0",
+ "serde",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -5169,7 +5170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "ucd-trie",
 ]
 
@@ -5611,6 +5612,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5629,6 +5636,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -5674,6 +5692,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -6605,7 +6629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -6622,7 +6646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -6728,7 +6752,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -6781,12 +6805,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6871,7 +6895,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -6953,7 +6977,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tracing",
  "whoami",
 ]
@@ -6990,7 +7014,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tracing",
  "whoami",
 ]
@@ -7014,7 +7038,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tracing",
  "url",
 ]
@@ -7334,11 +7358,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -7354,9 +7378,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7452,7 +7476,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2 0.6.0",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.59.0",
 ]
@@ -8052,12 +8076,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utxorpc"
-version = "0.10.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bea8f520897c0d0b8048413a2ad72044cc5cbc00c98219a750f048be616f3d7f"
+checksum = "869defa7e9baca52ad1a45eaecd60d9bb6bcddf0e6fb79041bc3a90489a1f5d7"
 dependencies = [
  "bytes",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tonic",
  "utxorpc-spec",
@@ -8065,9 +8089,9 @@ dependencies = [
 
 [[package]]
 name = "utxorpc-spec"
-version = "0.15.0"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c73cb3e15766a14cbc99fbd6dbbee04496fc9c64b47b088ae1d7698d43e357"
+checksum = "aa35373e6fbf0ea73651328aecd1641f92684de54bd908e3aa9855866b1c9875"
 dependencies = [
  "bytes",
  "futures-core",
@@ -8192,6 +8216,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8289,6 +8331,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.11.0",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8321,6 +8385,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ad4ca2ecb86b79ea410cd970985665de1d05774b7107b214bc5852b1bcbad7"
 dependencies = [
  "bitflags 2.9.3",
+ "indexmap 2.11.0",
+ "semver 1.0.26",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.9.3",
+ "hashbrown 0.15.5",
  "indexmap 2.11.0",
  "semver 1.0.26",
 ]
@@ -8435,7 +8511,7 @@ dependencies = [
  "syn 2.0.106",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser",
+ "wit-parser 0.224.1",
 ]
 
 [[package]]
@@ -8588,7 +8664,7 @@ dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap 2.11.0",
- "wit-parser",
+ "wit-parser 0.224.1",
 ]
 
 [[package]]
@@ -9106,12 +9182,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser 0.244.0",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.9.3",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.11.0",
+ "prettyplease",
+ "syn 2.0.106",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.9.3",
+ "indexmap 2.11.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.244.0",
+ "wasm-metadata",
+ "wasmparser 0.244.0",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -9130,6 +9282,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.224.1",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.11.0",
+ "log",
+ "semver 1.0.26",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -9174,7 +9344,7 @@ dependencies = [
  "nom 7.1.3",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ hydra = ["tungstenite", "tokio-tungstenite", "futures-util", "bytes"]
 # kafka = auto feature flag
 
 [dependencies]
-pallas = { version = "0.35", features = ["hardano"] }
+pallas = { version = "1.1", features = ["hardano"] }
 # pallas = { path = "../pallas/pallas", features = ["hardano"] }
 # pallas = { git = "https://github.com/txpipe/pallas", features = ["hardano"] }
 
@@ -76,7 +76,7 @@ mithril-client = { version = "^0.12.11", optional = true, features = ["fs"] }
 miette = { version = "7.2.0", features = ["fancy"] }
 itertools = "0.12.1"
 redis = { version = "0.27.6", optional = true }
-utxorpc = { version = "0.10.0", optional = true }
+utxorpc = { version = "0.14.0", optional = true }
 tungstenite = { version = "0.24.0", optional = true }
 tokio-tungstenite = { version = "0.24.0", optional = true }
 futures-util = { version = "0.3", optional = true }

--- a/src/filters/legacy_v1/crawl.rs
+++ b/src/filters/legacy_v1/crawl.rs
@@ -1,5 +1,5 @@
 use gasket::framework::{AsWorkError, WorkerError};
-use pallas::ledger::primitives::babbage::MintedDatumOption;
+use pallas::ledger::primitives::babbage::DatumOption;
 use pallas::ledger::traverse::{MultiEraBlock, MultiEraInput, MultiEraOutput, MultiEraTx};
 use pallas::network::miniprotocols::Point;
 
@@ -66,7 +66,7 @@ impl EventWriter<'_> {
             }
         }
 
-        if let Some(MintedDatumOption::Data(datum)) = &output.datum() {
+        if let Some(DatumOption::Data(datum)) = &output.datum() {
             child.append_from(PlutusDatumRecord::from(&datum.0))?;
         }
 

--- a/src/filters/legacy_v1/map.rs
+++ b/src/filters/legacy_v1/map.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::ops::Deref as _;
 use tracing::warn;
 
-use pallas::ledger::primitives::babbage::{MintedDatumOption, NetworkId};
+use pallas::ledger::primitives::babbage::{DatumOption, NetworkId};
 use pallas::ledger::primitives::{
     alonzo::{
         self as alonzo, Certificate, InstantaneousRewardSource, InstantaneousRewardTarget,
@@ -153,12 +153,12 @@ impl EventWriter<'_> {
                 .collect::<Vec<_>>()
                 .into(),
             datum_hash: match &output.datum() {
-                Some(MintedDatumOption::Hash(x)) => Some(x.to_string()),
-                Some(MintedDatumOption::Data(x)) => Some(x.original_hash().to_hex()),
+                Some(DatumOption::Hash(x)) => Some(x.to_string()),
+                Some(DatumOption::Data(x)) => Some(x.original_hash().to_hex()),
                 None => None,
             },
             inline_datum: match &output.datum() {
-                Some(MintedDatumOption::Data(x)) => Some(PlutusDatumRecord::from(x.deref())),
+                Some(DatumOption::Data(x)) => Some(PlutusDatumRecord::from(x.deref())),
                 _ => None,
             },
         }
@@ -491,14 +491,8 @@ impl EventWriter<'_> {
                 reward_account: reward_account.to_hex(),
                 pool_owners: pool_owners.iter().map(|p| p.to_hex()).collect(),
                 relays: relays.iter().map(relay_to_string).collect(),
-                pool_metadata: match pool_metadata {
-                    Some(x) => Some(x.url.clone()),
-                    _ => None,
-                },
-                pool_metadata_hash: match pool_metadata {
-                    Some(x) => Some(x.hash.clone().to_hex()),
-                    _ => None,
-                },
+                pool_metadata: pool_metadata.as_ref().map(|x| x.url.clone()),
+                pool_metadata_hash: pool_metadata.as_ref().map(|x| x.hash.clone().to_hex()),
             },
             Certificate::PoolRetirement(pool, epoch) => EventData::PoolRetirement {
                 pool: pool.to_hex(),

--- a/src/filters/legacy_v1/map.rs
+++ b/src/filters/legacy_v1/map.rs
@@ -1,5 +1,4 @@
 use gasket::framework::AsWorkError;
-use pallas::codec::utils::Nullable;
 use pallas::ledger::primitives::conway;
 use serde_json::{json, Value as JsonValue};
 use std::collections::HashMap;
@@ -108,18 +107,18 @@ fn relay_to_string(relay: &Relay) -> String {
     match relay {
         Relay::SingleHostAddr(port, ipv4, ipv6) => {
             let ip = match (ipv6, ipv4) {
-                (_, Nullable::Some(x)) => ip_string_from_bytes(x.as_ref()),
-                (Nullable::Some(x), _) => ip_string_from_bytes(x.as_ref()),
+                (_, Some(x)) => ip_string_from_bytes(x.as_ref()),
+                (Some(x), _) => ip_string_from_bytes(x.as_ref()),
                 _ => "".to_string(),
             };
 
             match port {
-                Nullable::Some(port) => format!("{ip}:{port}"),
+                Some(port) => format!("{ip}:{port}"),
                 _ => ip,
             }
         }
         Relay::SingleHostName(port, host) => match port {
-            Nullable::Some(port) => format!("{host}:{port}"),
+            Some(port) => format!("{host}:{port}"),
             _ => host.clone(),
         },
         Relay::MultiHostName(host) => host.clone(),
@@ -493,11 +492,11 @@ impl EventWriter<'_> {
                 pool_owners: pool_owners.iter().map(|p| p.to_hex()).collect(),
                 relays: relays.iter().map(relay_to_string).collect(),
                 pool_metadata: match pool_metadata {
-                    Nullable::Some(x) => Some(x.url.clone()),
+                    Some(x) => Some(x.url.clone()),
                     _ => None,
                 },
                 pool_metadata_hash: match pool_metadata {
-                    Nullable::Some(x) => Some(x.hash.clone().to_hex()),
+                    Some(x) => Some(x.hash.clone().to_hex()),
                     _ => None,
                 },
             },

--- a/src/filters/parse_cbor.rs
+++ b/src/filters/parse_cbor.rs
@@ -15,6 +15,10 @@ impl interop::LedgerContext for NoOpContext {
     fn get_utxos(&self, _refs: &[interop::TxoRef]) -> Option<interop::UtxoMap> {
         None
     }
+
+    fn get_slot_timestamp(&self, _slot: u64) -> Option<u64> {
+        None
+    }
 }
 
 #[derive(Default, Stage)]

--- a/src/filters/select/eval/assets.rs
+++ b/src/filters/select/eval/assets.rs
@@ -59,7 +59,7 @@ impl PatternOf<(&PolicyId, &Asset)> for AssetPattern {
 
         let d = self.name_text.is_match(subject_asset.name.as_ref());
 
-        let e = self.coin.is_match(subject_asset.output_coin);
+        let e = self.coin.is_match(asset_quantity_to_u64(subject_asset));
 
         MatchOutcome::fold_all_of([a, b, c, d, e].into_iter())
     }

--- a/src/filters/select/eval/metadata.rs
+++ b/src/filters/select/eval/metadata.rs
@@ -183,5 +183,4 @@ mod tests {
             MatchOutcome::Negative
         );
     }
-
 }

--- a/src/filters/select/eval/mod.rs
+++ b/src/filters/select/eval/mod.rs
@@ -1,7 +1,7 @@
 use std::{ops::Deref, str::FromStr};
 
 use pallas::interop::utxorpc::spec::cardano::{
-    Asset, AuxData, Metadata, Metadatum, Multiasset, TxInput, TxOutput,
+    asset, big_int, Asset, AuxData, BigInt, Metadata, Metadatum, Multiasset, TxInput, TxOutput,
 };
 use serde::{Deserialize, Serialize};
 use tracing::warn;
@@ -194,6 +194,29 @@ impl PatternOf<u64> for CoinPattern {
     }
 }
 
+/// Best-effort conversion of a u5c `BigInt` into a `u64` for numeric matching.
+/// Lovelace and native-asset quantities fit in `u64` in practice; the arbitrary-precision
+/// byte variants are folded big-endian and saturated, and negative values clamp to `0`.
+fn big_int_to_u64(value: Option<&BigInt>) -> u64 {
+    match value.and_then(|x| x.big_int.as_ref()) {
+        Some(big_int::BigInt::Int(x)) => (*x).try_into().unwrap_or_default(),
+        Some(big_int::BigInt::BigUInt(bytes)) => bytes
+            .iter()
+            .fold(0u64, |acc, b| acc.saturating_mul(256).saturating_add(*b as u64)),
+        Some(big_int::BigInt::BigNInt(_)) | None => 0,
+    }
+}
+
+/// Extracts the numeric quantity of a u5c `Asset` (output or mint coin) as a `u64`.
+fn asset_quantity_to_u64(asset: &Asset) -> u64 {
+    match asset.quantity.as_ref() {
+        Some(asset::Quantity::OutputCoin(x)) | Some(asset::Quantity::MintCoin(x)) => {
+            big_int_to_u64(Some(x))
+        }
+        None => 0,
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "lowercase")]
 pub enum TextPattern {
@@ -305,7 +328,7 @@ impl PatternOf<&TxOutput> for OutputPattern {
     fn is_match(&self, subject: &TxOutput) -> MatchOutcome {
         let a = self.address.is_match(subject.address.as_ref());
 
-        let b = self.lovelace.is_match(subject.coin);
+        let b = self.lovelace.is_match(big_int_to_u64(subject.coin.as_ref()));
 
         let c = self
             .assets
@@ -348,7 +371,7 @@ impl PatternOf<&TxInput> for InputPattern {
 
         let a = self.address.is_match(as_output.address.as_ref());
 
-        let b = self.lovelace.is_match(as_output.coin);
+        let b = self.lovelace.is_match(big_int_to_u64(as_output.coin.as_ref()));
 
         let c = self
             .assets

--- a/src/filters/select/eval/mod.rs
+++ b/src/filters/select/eval/mod.rs
@@ -200,9 +200,9 @@ impl PatternOf<u64> for CoinPattern {
 fn big_int_to_u64(value: Option<&BigInt>) -> u64 {
     match value.and_then(|x| x.big_int.as_ref()) {
         Some(big_int::BigInt::Int(x)) => (*x).try_into().unwrap_or_default(),
-        Some(big_int::BigInt::BigUInt(bytes)) => bytes
-            .iter()
-            .fold(0u64, |acc, b| acc.saturating_mul(256).saturating_add(*b as u64)),
+        Some(big_int::BigInt::BigUInt(bytes)) => bytes.iter().fold(0u64, |acc, b| {
+            acc.saturating_mul(256).saturating_add(*b as u64)
+        }),
         Some(big_int::BigInt::BigNInt(_)) | None => 0,
     }
 }
@@ -328,7 +328,9 @@ impl PatternOf<&TxOutput> for OutputPattern {
     fn is_match(&self, subject: &TxOutput) -> MatchOutcome {
         let a = self.address.is_match(subject.address.as_ref());
 
-        let b = self.lovelace.is_match(big_int_to_u64(subject.coin.as_ref()));
+        let b = self
+            .lovelace
+            .is_match(big_int_to_u64(subject.coin.as_ref()));
 
         let c = self
             .assets
@@ -371,7 +373,9 @@ impl PatternOf<&TxInput> for InputPattern {
 
         let a = self.address.is_match(as_output.address.as_ref());
 
-        let b = self.lovelace.is_match(big_int_to_u64(as_output.coin.as_ref()));
+        let b = self
+            .lovelace
+            .is_match(big_int_to_u64(as_output.coin.as_ref()));
 
         let c = self
             .assets

--- a/src/filters/select/eval/testing.rs
+++ b/src/filters/select/eval/testing.rs
@@ -2,19 +2,29 @@ use pallas::interop::utxorpc::spec::cardano::{metadatum, AuxData, Datum, Metadat
 
 use super::*;
 
+fn coin(value: i64) -> Option<BigInt> {
+    Some(BigInt {
+        big_int: Some(big_int::BigInt::Int(value)),
+    })
+}
+
+fn output_coin(value: i64) -> Option<asset::Quantity> {
+    Some(asset::Quantity::OutputCoin(BigInt {
+        big_int: Some(big_int::BigInt::Int(value)),
+    }))
+}
+
 pub fn multiasset_combo(policy_hex: &str, asset_prefix: &str) -> Multiasset {
     Multiasset {
         policy_id: hex::decode(policy_hex).unwrap().into(),
         assets: vec![
             Asset {
                 name: format!("{asset_prefix}1").as_bytes().to_vec().into(),
-                output_coin: 345000000,
-                mint_coin: 0,
+                quantity: output_coin(345000000),
             },
             Asset {
                 name: format!("{asset_prefix}2").as_bytes().to_vec().into(),
-                output_coin: 345000000,
-                mint_coin: 0,
+                quantity: output_coin(345000000),
             },
         ],
         redeemer: None,
@@ -37,7 +47,7 @@ pub fn test_vectors() -> Vec<Tx> {
     let tx1 = Tx {
         outputs: vec![TxOutput {
             address: hex::decode("019493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251").unwrap().into(),
-            coin: 123000000,
+            coin: coin(123000000),
             assets: vec![
                 multiasset_combo("7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373", "abc"),
                 multiasset_combo("1e349c9bdea19fd6c147626a5260bc44b71635f398b67c59881df209", "123")
@@ -63,7 +73,7 @@ pub fn test_vectors() -> Vec<Tx> {
             address: hex::decode("619493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e")
                 .unwrap()
                 .into(),
-            coin: 123000000,
+            coin: coin(123000000),
             assets: vec![multiasset_combo(
                 "7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373",
                 "abc",
@@ -93,7 +103,7 @@ pub fn test_vectors() -> Vec<Tx> {
     let tx3 = Tx {
         outputs: vec![TxOutput {
             address: hex::decode("019493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251").unwrap().into(),
-            coin: 123000000,
+            coin: coin(123000000),
             assets: vec![
                 multiasset_combo("1e349c9bdea19fd6c147626a5260bc44b71635f398b67c59881df209", "123")
             ],

--- a/src/sources/mithril.rs
+++ b/src/sources/mithril.rs
@@ -204,22 +204,32 @@ fn read_blocks_with_config(
     immutable_path: &Path,
     config: &IntersectConfig,
 ) -> Result<
-    Box<dyn Iterator<Item = pallas::interop::hardano::storage::immutable::FallibleBlock> + Send + Sync>,
+    Box<
+        dyn Iterator<Item = pallas::interop::hardano::storage::immutable::FallibleBlock>
+            + Send
+            + Sync,
+    >,
     WorkerError,
 > {
     let starting_points =
         get_starting_points(immutable_path, config).map_err(|_| WorkerError::Panic)?;
 
     for point in starting_points {
-        match pallas::interop::hardano::storage::immutable::read_blocks_from_point(immutable_path, point) {
+        match pallas::interop::hardano::storage::immutable::read_blocks_from_point(
+            immutable_path,
+            point,
+        ) {
             Ok(iter) => return Ok(iter),
             Err(_) => continue,
         }
     }
 
     // If all points fail (or if the list was empty), try from Origin
-    pallas::interop::hardano::storage::immutable::read_blocks_from_point(immutable_path, Point::Origin)
-        .map_err(|_| WorkerError::Panic)
+    pallas::interop::hardano::storage::immutable::read_blocks_from_point(
+        immutable_path,
+        Point::Origin,
+    )
+    .map_err(|_| WorkerError::Panic)
 }
 
 #[derive(Stage)]

--- a/src/sources/mithril.rs
+++ b/src/sources/mithril.rs
@@ -183,7 +183,7 @@ fn get_starting_points(
     config: &IntersectConfig,
 ) -> Result<Vec<Point>, Box<dyn std::error::Error>> {
     match config {
-        IntersectConfig::Tip => pallas::storage::hardano::immutable::get_tip(dir)?
+        IntersectConfig::Tip => pallas::interop::hardano::storage::immutable::get_tip(dir)?
             .map_or(Ok(vec![Point::Origin]), |point| Ok(vec![point])),
         IntersectConfig::Origin => Ok(vec![Point::Origin]),
         IntersectConfig::Point(slot, hash) => {
@@ -204,21 +204,21 @@ fn read_blocks_with_config(
     immutable_path: &Path,
     config: &IntersectConfig,
 ) -> Result<
-    Box<dyn Iterator<Item = pallas::storage::hardano::immutable::FallibleBlock> + Send + Sync>,
+    Box<dyn Iterator<Item = pallas::interop::hardano::storage::immutable::FallibleBlock> + Send + Sync>,
     WorkerError,
 > {
     let starting_points =
         get_starting_points(immutable_path, config).map_err(|_| WorkerError::Panic)?;
 
     for point in starting_points {
-        match pallas::storage::hardano::immutable::read_blocks_from_point(immutable_path, point) {
+        match pallas::interop::hardano::storage::immutable::read_blocks_from_point(immutable_path, point) {
             Ok(iter) => return Ok(iter),
             Err(_) => continue,
         }
     }
 
     // If all points fail (or if the list was empty), try from Origin
-    pallas::storage::hardano::immutable::read_blocks_from_point(immutable_path, Point::Origin)
+    pallas::interop::hardano::storage::immutable::read_blocks_from_point(immutable_path, Point::Origin)
         .map_err(|_| WorkerError::Panic)
 }
 

--- a/src/sources/u5c.rs
+++ b/src/sources/u5c.rs
@@ -4,7 +4,7 @@ use gasket::framework::*;
 use pallas::interop::utxorpc::spec::sync::BlockRef;
 use pallas::network::miniprotocols::Point;
 use serde::Deserialize;
-use tracing::debug;
+use tracing::{debug, error};
 use utxorpc::{CardanoSyncClient, ChainBlock, ClientBuilder, TipEvent};
 
 use crate::framework::*;
@@ -13,8 +13,9 @@ fn point_to_blockref(point: Point) -> Option<BlockRef> {
     match point {
         Point::Origin => None,
         Point::Specific(slot, hash) => Some(BlockRef {
-            index: slot,
+            slot,
             hash: hash.into(),
+            ..Default::default()
         }),
     }
 }
@@ -71,11 +72,11 @@ impl Worker {
             TipEvent::Reset(block) => {
                 stage
                     .output
-                    .send(ChainEvent::Reset(Point::new(block.index, block.hash.to_vec())).into())
+                    .send(ChainEvent::Reset(Point::new(block.slot, block.hash.to_vec())).into())
                     .await
                     .or_panic()?;
 
-                stage.chain_tip.set(block.index as i64);
+                stage.chain_tip.set(block.slot as i64);
             }
         }
 
@@ -124,7 +125,17 @@ impl gasket::framework::Worker<Stage> for Worker {
         &mut self,
         _: &mut Stage,
     ) -> Result<WorkSchedule<TipEvent<utxorpc::Cardano>>, WorkerError> {
-        let event = self.stream.event().await.or_restart()?;
+        let event = self
+            .stream
+            .event()
+            .await
+            .inspect_err(|err| error!(?err, "utxorpc stream error"))
+            .or_restart()?;
+
+        // a `None` event means the server closed the stream; restart to reconnect.
+        let Some(event) = event else {
+            return Err(WorkerError::Restart);
+        };
 
         Ok(WorkSchedule::Unit(event))
     }


### PR DESCRIPTION
## Context

Fixes #921. When using the `U5C` (UTxORPC) source against a current server such as Demeter, Oura emitted a single `reset` event and then looped on `x=grpc error` with no apply events.

The root cause is a **breaking change in the UTxORPC spec**. Oura was pinned to `utxorpc-spec 0.15` (via `utxorpc` 0.10 and `pallas` 0.35), but servers now speak `0.19`, in which `BlockRef.index` was renamed to `slot`. The actual gRPC status was also masked: `utxorpc::Error::GrpcError`'s `Display` is the literal string `"grpc error"`, so the underlying `tonic::Status` (code + message) never reached the logs.

## Approach

Decoupling Oura's parsed-data model from pallas was considered and rejected: pallas owns the `ParsedBlock`/`ParsedTx` types (the core `Record` model), the `select` predicate engine, and the CBOR→spec mapper used by `parse_cbor` — there is no standalone replacement. Instead, **bump pallas and utxorpc together** so both resolve a single `utxorpc-spec 0.19`:

- `utxorpc` `0.10` → `0.14`
- `pallas` `0.35` → `1.1`

## Changes

- **`sources/u5c.rs`** — `BlockRef.index` → `slot`; handle `LiveTip::event()` now returning `Option<TipEvent>` (None = server closed the stream → restart); log the real gRPC status via `inspect_err(… error!(?err))` before restarting, instead of the opaque `"grpc error"` that masked this issue.
- **`select/eval/{mod,assets,testing}.rs`** — `TxOutput.coin: u64` → `Option<BigInt>` and `Asset.{output_coin,mint_coin}` → `Asset.quantity: Option<asset::Quantity>`. Added `big_int_to_u64` / `asset_quantity_to_u64` helpers and routed the predicate call sites + test fixtures through them.
- **`filters/parse_cbor.rs`** — implement new `LedgerContext::get_slot_timestamp` (returns `None` for the no-op context).
- **`legacy_v1/map.rs`** — pallas 1.1 changed `Relay`/`PoolMetadata` fields from `Nullable<T>` to `Option<T>`.
- **`sources/mithril.rs`** — `pallas::storage::hardano::immutable` → `pallas::interop::hardano::storage::immutable`.

## Verification

- `cargo check --all-features` → clean (all features typecheck)
- `cargo build` (default) and `cargo build --features u5c` → link OK
- `cargo test --features u5c` → 18/18 pass

## Notes

- `cargo build --all-features` fails at the final **binary link** with undefined GMP/MPFR symbols from `mithril_stm`/`rug`. This is a pre-existing native-C-library issue from the `mithril` feature, unrelated to this change (confirmed by `cargo check --all-features` passing).
- The `BigInt` byte-variant path in `big_int_to_u64` is best-effort/saturating; real lovelace and native-asset amounts use the `Int(i64)` variant, so the common path is exact.
- A live Demeter preprod run still needs validation with an API key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded core dependencies (pallas to v1.1, utxorpc to v0.14.0) for improved stability and compatibility.

* **Bug Fixes**
  * Improved numeric matching for coin/asset quantities to handle large on-chain values safely.
  * More robust relay and pool metadata handling; corrected metadata byte-pattern check.
  * Enhanced error logging and stream handling to better recover from stream failures.

* **Tests**
  * Added/updated test helpers and vectors for asset/coin quantity handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->