### PR TITLE
fix: clear pre-existing clippy lints to unblock Lint CI

### DIFF
--- a/src/filters/select/eval/mod.rs
+++ b/src/filters/select/eval/mod.rs
@@ -728,7 +728,7 @@ mod tests {
         let utf8_no_match = b"goodbye";
         assert_eq!(pattern.is_match(&utf8_no_match[..]), MatchOutcome::Negative);
 
-        let invalid_utf8 = vec![0xFF, 0xFE, 0xFD];
+        let invalid_utf8 = [0xFF, 0xFE, 0xFD];
         assert_eq!(pattern.is_match(&invalid_utf8[..]), MatchOutcome::Uncertain);
     }
 

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -65,20 +65,15 @@ impl Breadcrumbs {
     }
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Default)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum ChainConfig {
+    #[default]
     Mainnet,
     Testnet,
     PreProd,
     Preview,
     Custom(GenesisValues),
-}
-
-impl Default for ChainConfig {
-    fn default() -> Self {
-        Self::Mainnet
-    }
 }
 
 impl From<ChainConfig> for GenesisValues {

--- a/src/sinks/redis.rs
+++ b/src/sinks/redis.rs
@@ -86,11 +86,6 @@ pub struct Stage {
     latest_block: gasket::metrics::Gauge,
 }
 
-#[derive(Debug, Clone, Deserialize)]
-pub enum StreamStrategy {
-    ByBlock,
-}
-
 #[derive(Default, Debug, Deserialize)]
 pub struct Config {
     pub url: String,


### PR DESCRIPTION
## Context

The `Lint Rust` CI job has been red for a long time, but it was actually failing at the **`cargo fmt`** step — so `cargo clippy` never ran and a handful of latent lints accumulated unnoticed. #924 fixed formatting, which let clippy run for the first time and surfaced these. #924 fixed the lints it introduced; this PR clears the remaining **pre-existing** ones so the job (`cargo clippy --all-features --all-targets -- -D warnings`) goes green.

None of these were touched by #924 — they predate it.

## Changes

- **`framework/mod.rs`** — derive `Default` for `ChainConfig` (with `#[default]` on `Mainnet`) instead of a hand-written `impl Default`. (`this impl can be derived`)
- **`filters/select/eval/mod.rs`** — use an array literal instead of `vec!` in a test fixture. (`useless use of vec!`)
- **`sinks/redis.rs`** — remove the unused `StreamStrategy` enum; it had no field in `Config` and was referenced nowhere. (`enum StreamStrategy is never used`)

## Verification

- `cargo clippy --all-features --all-targets -- -D warnings` → clean (exit 0)
- `cargo fmt --check` → clean
- `cargo test --features u5c` → 18/18 pass

## Note

The Windows `Check` job may still fail on an environmental `aws-lc-sys` / MSVC C-compilation issue (new runner toolchain vs. a stale native dep) — unrelated to this PR and not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal configuration management using standard derive macros.
  * Removed an unused internal type from the Redis sink module.

* **Tests**
  * Updated test data structures for improved test clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->