### PR TITLE
feat: add work_stats filter with finalization policy

### DIFF
--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -10,6 +10,7 @@ pub mod parse_cbor;
 pub mod rollback_buffer;
 pub mod select;
 pub mod split_block;
+pub mod work_stats;
 
 #[cfg(feature = "wasm")]
 pub mod wasm_plugin;
@@ -23,6 +24,7 @@ pub enum Bootstrapper {
     ParseCbor(parse_cbor::Stage),
     Select(select::Stage),
     RollbackBuffer(rollback_buffer::Stage),
+    WorkStats(work_stats::Stage),
 
     #[cfg(feature = "wasm")]
     WasmPlugin(wasm_plugin::Stage),
@@ -38,6 +40,7 @@ impl Bootstrapper {
             Bootstrapper::ParseCbor(p) => &mut p.input,
             Bootstrapper::Select(p) => &mut p.input,
             Bootstrapper::RollbackBuffer(p) => &mut p.input,
+            Bootstrapper::WorkStats(p) => &mut p.input,
 
             #[cfg(feature = "wasm")]
             Bootstrapper::WasmPlugin(p) => &mut p.input,
@@ -53,6 +56,7 @@ impl Bootstrapper {
             Bootstrapper::ParseCbor(p) => &mut p.output,
             Bootstrapper::Select(p) => &mut p.output,
             Bootstrapper::RollbackBuffer(p) => &mut p.output,
+            Bootstrapper::WorkStats(p) => &mut p.output,
 
             #[cfg(feature = "wasm")]
             Bootstrapper::WasmPlugin(p) => &mut p.output,
@@ -68,6 +72,7 @@ impl Bootstrapper {
             Bootstrapper::ParseCbor(x) => gasket::runtime::spawn_stage(x, policy),
             Bootstrapper::Select(x) => gasket::runtime::spawn_stage(x, policy),
             Bootstrapper::RollbackBuffer(x) => gasket::runtime::spawn_stage(x, policy),
+            Bootstrapper::WorkStats(x) => gasket::runtime::spawn_stage(x, policy),
 
             #[cfg(feature = "wasm")]
             Bootstrapper::WasmPlugin(x) => gasket::runtime::spawn_stage(x, policy),
@@ -85,6 +90,7 @@ pub enum Config {
     ParseCbor(parse_cbor::Config),
     Select(select::Config),
     RollbackBuffer(rollback_buffer::Config),
+    WorkStats(work_stats::Config),
 
     #[cfg(feature = "wasm")]
     WasmPlugin(wasm_plugin::Config),
@@ -100,6 +106,7 @@ impl Config {
             Config::ParseCbor(c) => Ok(Bootstrapper::ParseCbor(c.bootstrapper(ctx)?)),
             Config::Select(c) => Ok(Bootstrapper::Select(c.bootstrapper(ctx)?)),
             Config::RollbackBuffer(c) => Ok(Bootstrapper::RollbackBuffer(c.bootstrapper(ctx)?)),
+            Config::WorkStats(c) => Ok(Bootstrapper::WorkStats(c.bootstrapper(ctx)?)),
 
             #[cfg(feature = "wasm")]
             Config::WasmPlugin(c) => Ok(Bootstrapper::WasmPlugin(c.bootstrapper(ctx)?)),

--- a/src/filters/work_stats.rs
+++ b/src/filters/work_stats.rs
@@ -1,0 +1,126 @@
+//! A pass-through filter that tracks work stats and enforces a finalization
+//! policy.
+//!
+//! Today its observable behavior is the finalization policy: it forwards every
+//! event downstream unchanged while counting applied blocks, and once the
+//! configured policy is reached it ends its stage, which gracefully stops the
+//! whole daemon (gasket halts when any stage reaches `Ended`). Because it lives
+//! in the filter chain it is decoupled from any particular source.
+//!
+//! It is framed as `work_stats` so it can grow into a home for richer
+//! progress/throughput stats in the future; the metrics below are the seed of
+//! that.
+
+use gasket::framework::*;
+use serde::Deserialize;
+use tracing::info;
+
+use crate::framework::*;
+
+#[derive(Stage)]
+#[stage(name = "filter-work-stats", unit = "ChainEvent", worker = "Worker")]
+pub struct Stage {
+    pub input: FilterInputPort,
+    pub output: FilterOutputPort,
+
+    finalize: FinalizeConfig,
+
+    #[metric]
+    ops_count: gasket::metrics::Counter,
+
+    #[metric]
+    block_count: gasket::metrics::Counter,
+
+    #[metric]
+    latest_slot: gasket::metrics::Gauge,
+}
+
+#[derive(Default)]
+pub struct Worker {
+    blocks: u64,
+    finished: bool,
+}
+
+#[async_trait::async_trait(?Send)]
+impl gasket::framework::Worker<Stage> for Worker {
+    async fn bootstrap(_: &Stage) -> Result<Self, WorkerError> {
+        Ok(Default::default())
+    }
+
+    async fn schedule(
+        &mut self,
+        stage: &mut Stage,
+    ) -> Result<WorkSchedule<ChainEvent>, WorkerError> {
+        // once the finalization policy has been reached we end the stage, which
+        // signals the daemon to tear down the whole pipeline.
+        if self.finished {
+            return Ok(WorkSchedule::Done);
+        }
+
+        let msg = stage.input.recv().await.or_panic()?;
+        Ok(WorkSchedule::Unit(msg.payload))
+    }
+
+    async fn execute(&mut self, unit: &ChainEvent, stage: &mut Stage) -> Result<(), WorkerError> {
+        // forward downstream unchanged; this filter never mutates the stream.
+        stage.output.send(unit.clone().into()).await.or_panic()?;
+
+        // finalization is keyed on applied blocks, mirroring the v1 source
+        // `max_block_quantity` semantics. Undo/Reset still advance the policy's
+        // notion of the latest point but don't count towards the block total.
+        let point = match unit {
+            ChainEvent::Apply(point, _) => {
+                self.blocks += 1;
+                stage.block_count.inc(1);
+                stage.latest_slot.set(point.slot_or_default() as i64);
+                point.clone()
+            }
+            ChainEvent::Undo(point, _) => point.clone(),
+            ChainEvent::Reset(point) => point.clone(),
+        };
+
+        stage.ops_count.inc(1);
+
+        if should_finalize(&stage.finalize, &point, self.blocks) {
+            info!(
+                blocks = self.blocks,
+                slot = point.slot_or_default(),
+                "work-stats finalization policy reached, stopping pipeline"
+            );
+            self.finished = true;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Deserialize, Default)]
+pub struct Config {
+    #[serde(default)]
+    pub until_hash: Option<String>,
+
+    #[serde(default)]
+    pub max_block_slot: Option<u64>,
+
+    #[serde(default)]
+    pub max_block_quantity: Option<u64>,
+}
+
+impl Config {
+    pub fn bootstrapper(self, _ctx: &Context) -> Result<Stage, Error> {
+        let stage = Stage {
+            finalize: FinalizeConfig {
+                until_hash: self.until_hash,
+                max_block_slot: self.max_block_slot,
+                max_block_quantity: self.max_block_quantity,
+            },
+            input: Default::default(),
+            output: Default::default(),
+            ops_count: Default::default(),
+            block_count: Default::default(),
+            latest_slot: Default::default(),
+        };
+
+        Ok(stage)
+    }
+}

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -281,24 +281,15 @@ impl IntersectConfig {
 /// Optional configuration to stop processing new blocks after processing:
 ///   1. a block with the given hash
 ///   2. the first block on or after a given absolute slot
-///   3. TODO: a total of X blocks
-#[derive(Deserialize, Debug, Clone)]
+///   3. a total of X blocks
+#[derive(Deserialize, Debug, Clone, Default)]
 pub struct FinalizeConfig {
-    until_hash: Option<String>,
-    max_block_slot: Option<u64>,
-    // max_block_quantity: Option<u64>,
+    pub until_hash: Option<String>,
+    pub max_block_slot: Option<u64>,
+    pub max_block_quantity: Option<u64>,
 }
 
-pub fn should_finalize(
-    config: &Option<FinalizeConfig>,
-    last_point: &Point,
-    // block_count: u64,
-) -> bool {
-    let config = match config {
-        Some(x) => x,
-        None => return false,
-    };
-
+pub fn should_finalize(config: &FinalizeConfig, last_point: &Point, block_count: u64) -> bool {
     if let Some(expected) = &config.until_hash {
         if let Point::Specific(_, current) = last_point {
             return expected == &hex::encode(current);
@@ -311,11 +302,59 @@ pub fn should_finalize(
         }
     }
 
-    // if let Some(max) = config.max_block_quantity {
-    //     if block_count >= max {
-    //         return true;
-    //     }
-    // }
+    if let Some(max) = config.max_block_quantity {
+        if block_count >= max {
+            return true;
+        }
+    }
 
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn point(slot: u64, hash_hex: &str) -> Point {
+        Point::Specific(slot, hex::decode(hash_hex).unwrap())
+    }
+
+    #[test]
+    fn empty_policy_never_finalizes() {
+        let cfg = FinalizeConfig::default();
+        assert!(!should_finalize(&cfg, &point(100, "abcd"), 0));
+        assert!(!should_finalize(&cfg, &point(100, "abcd"), 1_000_000));
+    }
+
+    #[test]
+    fn max_block_quantity_finalizes_at_or_after_count() {
+        let cfg = FinalizeConfig {
+            max_block_quantity: Some(20),
+            ..Default::default()
+        };
+        assert!(!should_finalize(&cfg, &point(100, "abcd"), 19));
+        assert!(should_finalize(&cfg, &point(100, "abcd"), 20));
+        assert!(should_finalize(&cfg, &point(100, "abcd"), 21));
+    }
+
+    #[test]
+    fn max_block_slot_finalizes_at_or_after_slot() {
+        let cfg = FinalizeConfig {
+            max_block_slot: Some(500),
+            ..Default::default()
+        };
+        assert!(!should_finalize(&cfg, &point(499, "abcd"), 0));
+        assert!(should_finalize(&cfg, &point(500, "abcd"), 0));
+        assert!(should_finalize(&cfg, &point(501, "abcd"), 0));
+    }
+
+    #[test]
+    fn until_hash_finalizes_on_matching_hash() {
+        let cfg = FinalizeConfig {
+            until_hash: Some("abcd".to_string()),
+            ..Default::default()
+        };
+        assert!(should_finalize(&cfg, &point(100, "abcd"), 0));
+        assert!(!should_finalize(&cfg, &point(100, "beef"), 999));
+    }
 }


### PR DESCRIPTION
> **PR 1 of 3** in the e2e-on-GitHub-runners sequence: ① this → ② pipeline termination exit code → ③ e2e test migration.

## What

Adds a pass-through `WorkStats` filter that tracks work stats and enforces a finalization policy (`until_hash` / `max_block_slot` / `max_block_quantity`). When the policy is reached the filter ends its stage, which signals the daemon to stop (gasket halts once any stage reaches `Ended`).

- **Decoupled from sources**: restores the v1 source `finalize` semantics for *every* source at once (n2n, n2c, u5c, mithril, …). The v2 `finalize` config was dead code — `should_finalize` had no callers and `max_block_quantity` was commented out.
- Re-enables `max_block_quantity`; the block counter lives naturally in the filter.
- Framed as `work_stats` so it can grow into a home for richer progress/throughput stats; the `block_count` / `latest_slot` metrics are the seed.
- Reuses `framework::FinalizeConfig` / `should_finalize` (fields made public, quantity branch restored) and adds unit tests for the policy.

## Why

The e2e suite's design is "run `oura daemon`, judge by exit code": a test must process N blocks and stop. This filter is the termination mechanism (used by PR 3); without it a pipeline never self-terminates.

## Verification

- `cargo test` → 22 passed (4 new finalize-policy tests)
- `cargo clippy --all-features --all-targets -- -D warnings` clean; fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a work statistics filter stage that tracks pipeline metrics including operation counts, block counts, and latest slot information.
  * Introduced block quantity-based finalization limits alongside existing slot and hash-based finalization policies for enhanced pipeline control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->