### PR TITLE
fix: bump gasket to 0.10 and derive exit code from finalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,7 +1248,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes 2.0.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1265,7 +1265,7 @@ dependencies = [
  "maybe-owned",
  "rustix 1.0.8",
  "rustix-linux-procfs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -2390,7 +2390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2535,7 +2535,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2666,7 +2666,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes 2.0.4",
  "rustix 1.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2827,24 +2827,26 @@ dependencies = [
 
 [[package]]
 name = "gasket"
-version = "0.7.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b0e0817f9ef592c3a1788550b66bccaa8d58c7a52f1ed9996828130158bf5d"
+checksum = "8771782404fba032679618d44384860915ec207280da85875af68ac14b927f7e"
 dependencies = [
  "async-trait",
  "crossbeam",
  "gasket-derive",
  "serde",
+ "signal-hook",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 
 [[package]]
 name = "gasket-derive"
-version = "0.7.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f280aa9c78c708fddd07172482e39e9e6cc8a4d353b76de811d7b06c791245b"
+checksum = "b9ae3e06e548bded6877e630f2f97836e99a9de6feb08caa3eebd5145cc6bd75"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2853,9 +2855,9 @@ dependencies = [
 
 [[package]]
 name = "gasket-prometheus"
-version = "0.7.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8582f2a30cebd31ebc3d88ce3eeeb96cf9f8d466e79f233474b52d67f4373f5c"
+checksum = "3188cde2a64bca0cf0709cdf79372200536062e161b977c49e5765f7af34ced3"
 dependencies = [
  "gasket",
  "prometheus_exporter_base",
@@ -3432,7 +3434,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -3653,7 +3655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes 2.0.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3708,7 +3710,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6051,7 +6053,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6064,7 +6066,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7194,7 +7196,7 @@ dependencies = [
  "fd-lock",
  "io-lifetimes 2.0.4",
  "rustix 0.38.44",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -7249,7 +7251,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8755,7 +8757,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9100,7 +9102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.9.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ pallas = { version = "1.1", features = ["hardano"] }
 # pallas = { path = "../pallas/pallas", features = ["hardano"] }
 # pallas = { git = "https://github.com/txpipe/pallas", features = ["hardano"] }
 
-gasket = { version = "^0.7", features = ["derive"] }
-gasket-prometheus = { version = "^0.7" }
+gasket = { version = "^0.10", features = ["derive"] }
+gasket-prometheus = { version = "^0.10" }
 # gasket = { path = "../../construkts/gasket-rs/gasket", features = ["derive"] }
 # gasket = { git = "https://github.com/construkts/gasket-rs.git", features = ["derive"] }
 

--- a/src/bin/oura/console.rs
+++ b/src/bin/oura/console.rs
@@ -56,6 +56,7 @@ impl TuiConsole {
                     gasket::runtime::StagePhase::Teardown => "tearing down...",
                     gasket::runtime::StagePhase::Ended => "ended",
                 },
+                gasket::runtime::TetherState::Finished(_) => "finished",
             };
 
             match tether.read_metrics() {

--- a/src/bin/oura/dump.rs
+++ b/src/bin/oura/dump.rs
@@ -58,11 +58,10 @@ pub fn run(args: &Args) -> Result<(), Error> {
 
     let daemon = run_daemon(config)?;
 
+    // `block` consumes the daemon and tears the stages down on stop.
     daemon.block();
 
     info!("oura is stopping");
-
-    daemon.teardown();
 
     Ok(())
 }

--- a/src/bin/oura/run_daemon.rs
+++ b/src/bin/oura/run_daemon.rs
@@ -64,15 +64,49 @@ pub fn run(args: &Args) -> Result<(), Error> {
     let prometheus = tokio_rt.spawn(serve_prometheus(daemon.clone(), metrics));
     let tui = tokio_rt.spawn(console::render(daemon.clone(), args.tui));
 
-    daemon.block();
+    // `block`/`teardown` consume the `Daemon`, but it's shared via `Arc` with the
+    // prometheus + tui tasks, so we drive the stop loop over `&self` ourselves.
+    while !daemon.should_stop() {
+        std::thread::sleep(std::time::Duration::from_millis(1500));
+    }
 
     info!("oura is stopping");
 
-    daemon.teardown();
     prometheus.abort();
     tui.abort();
 
-    Ok(())
+    // Capture *why* the pipeline stopped before tearing down (teardown ends every
+    // stage). A stage that reached `Ended` means a finalization filter completed
+    // gracefully — only such filters self-end, so other stages erroring out as a
+    // teardown side effect don't confuse this. Any other stop with no `Ended`
+    // stage is a crashed/stalled stage, unless the user sent a termination signal.
+    use gasket::runtime::{StagePhase, TetherState};
+    let finalized = daemon.tethers().any(|tether| {
+        matches!(
+            tether.check_state(),
+            TetherState::Alive(StagePhase::Ended) | TetherState::Finished(StagePhase::Ended)
+        )
+    });
+    let terminated = daemon.is_terminated();
+
+    // wait for the aborted tasks to drop their `Arc` clones so we can reclaim
+    // sole ownership and tear the stages down gracefully.
+    tokio_rt.block_on(async {
+        let _ = prometheus.await;
+        let _ = tui.await;
+    });
+
+    if let Ok(daemon) = Arc::try_unwrap(daemon) {
+        daemon.teardown();
+    }
+
+    if finalized || terminated {
+        Ok(())
+    } else {
+        Err(Error::custom(
+            "pipeline stopped before finalizing (a stage crashed or stalled)",
+        ))
+    }
 }
 
 #[derive(clap::Args)]

--- a/src/bin/oura/watch.rs
+++ b/src/bin/oura/watch.rs
@@ -55,11 +55,10 @@ pub fn run(args: &Args) -> Result<(), Error> {
 
     let daemon = run_daemon(config)?;
 
+    // `block` consumes the daemon and tears the stages down on stop.
     daemon.block();
 
     info!("oura is stopping");
-
-    daemon.teardown();
 
     Ok(())
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -86,7 +86,7 @@ fn connect_stages(
     tethers.push(sink.spawn(policy.clone()));
     tethers.push(cursor.spawn(policy));
 
-    let runtime = Daemon(tethers);
+    let runtime = Daemon::new(tethers);
 
     Ok(runtime)
 }


### PR DESCRIPTION
> **PR 2 of 3** in the e2e-on-GitHub-runners sequence: ① work_stats filter (#928) → ② this → ③ e2e test migration. Based on #928; will retarget to `main` when it merges.

## Problem

Two termination-signal bugs, both observed on a live e2e run:

1. **Graceful finalization exited 101.** gasket 0.7's `Daemon::teardown` calls `dismiss_stage().expect("stage stops")`, which panics on a stage that already ended — exactly what happens when a finalization filter stops the pipeline (`stage stops: TetherDropped` at `daemon.rs:28`).
2. **A crashed stage was indistinguishable from a finished one.** `check_state` collapsed both to `Dropped`, so the process couldn't choose a meaningful exit code.

## Change

Bump gasket 0.7 → **0.10**, which carries the fixes (non-panicking teardown + the new `TetherState::Finished(StagePhase)` from construkts/gasket-rs#35), and adapt:

- `Daemon(tethers)` → `Daemon::new(tethers)`; `block`/`teardown` now consume `Daemon` (`dump`/`watch` just call `block`); `console` renders the new `Finished` state.
- `run_daemon` shares the daemon via `Arc` with the prometheus/tui tasks, so it drives the stop loop over `&self` and reclaims ownership for a graceful teardown.
- **Exit code now derives from the stages' terminal state.** In 0.10 a crashing stage no longer aborts the process (stages are thread-isolated), so a naive port would exit 0 on a crash. Now: a stage reached `Ended` (finalization completed) or a user TERM signal → exit 0; otherwise → non-zero ("pipeline stopped before finalizing").

This makes the e2e exit-code gate meaningful: WorkStats finalize → 0, Assert sink panic → ≠0, hang → timeout 124.

## Verification

- `cargo test` → 22 passed; clippy `--all-features -D warnings` clean; fmt clean
- Finalize-vs-crash semantics validated on a live e2e run in PR 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)