### PR TITLE
ci: build e2e image via the production native-build path

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,6 +16,32 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Build the binary and image the same way docker.yml does, so e2e
+      # exercises the production image (.github/image/Dockerfile) rather than a
+      # separate from-source build. e2e only runs on linux/amd64, so we build
+      # just that target.
+      - name: Install Rust toolchain
+        run: rustup show active-toolchain || rustup toolchain install
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Share the cache the docker.yml build populates from main so e2e
+          # dispatches restore a warm cache instead of compiling cold.
+          shared-key: docker-x86_64-unknown-linux-gnu
+
+      - name: Run cargo build
+        run: cargo build --target x86_64-unknown-linux-gnu --all-features --locked --release
+
+      - name: Stage binary for image
+        run: |
+          mkdir -p .github/image/bin
+          mv target/x86_64-unknown-linux-gnu/release/oura .github/image/bin/oura-Linux-amd64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -29,14 +55,10 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: .
-          # e2e only runs on the GitHub-hosted linux/amd64 runners, so we skip
-          # the armv7 cross-build that the release pipeline produces.
+          context: .github/image
           platforms: linux/amd64
           push: true
           tags: ${{ env.TARGET_IMAGE }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   test:
     needs: ["build"]


### PR DESCRIPTION
## Context

Follow-up to #933 (the new `docker.yml`). The e2e `build` job compiled oura from source **inside** Docker using the root `Dockerfile`, while `docker.yml` builds the binary natively and assembles the thin `.github/image/Dockerfile`. So e2e was validating a *different* image from the one we actually publish, and paying a cold from-source build each dispatch.

## What this does

Refactors the e2e `build` job to mirror `docker.yml`'s build path:

- Native `cargo build --target x86_64-unknown-linux-gnu --all-features --locked --release` (rustup honoring `rust-toolchain.toml` + `arduino/setup-protoc`).
- Stages the binary as `.github/image/bin/oura-Linux-amd64` and builds with `context: .github/image` — the **same runtime image** production ships.
- Reuses `Swatinem/rust-cache` with `shared-key: docker-x86_64-unknown-linux-gnu`, so e2e dispatches restore the warm cache `docker.yml` populates from `main` instead of compiling cold.

Net effects:
- **Correctness** — e2e now exercises the production image, not a divergent from-source build.
- **Speed** — warm Rust cache + the image build is now just a binary copy (the old `cache-from/to: type=gha` Docker-layer cache is no longer needed and was removed).

## Scope

- Only the `build` job changed; the `test` matrix is untouched.
- Stays `workflow_dispatch`-only — no trigger changes, not wired into the release.

## Caveat

On a branch dispatch with large dependency changes, the shared cache restores from `main`, so a partial rebuild is still possible — same trade-off as `docker.yml` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized continuous integration build pipeline with improved Docker image staging and enhanced build caching for faster, more efficient deployment cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->