### PR TITLE
ci: build e2e image on ubuntu-22.04 to match runtime glibc

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -9,7 +9,10 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # Pin to 22.04 (glibc 2.35) to match docker.yml: a binary built on 24.04
+    # links GLIBC_2.39, which the debian:12-slim runtime image (glibc 2.36)
+    # can't satisfy.
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Problem

The e2e run failed in every test leg with:

```
oura: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by oura)
```

Not a missing library — a **glibc version mismatch**. #934 switched e2e to a native build, but its `build` job ran on `ubuntu-latest` (now Ubuntu 24.04, glibc 2.39). The `.github/image/Dockerfile` runtime is `debian:12-slim` (glibc 2.36), which can't satisfy a `GLIBC_2.39` symbol. The `build` step passed; the failure only surfaced at runtime in the `test` legs.

## Fix

Pin the e2e `build` job to `ubuntu-22.04` (glibc 2.35) — the same runner `docker.yml` already uses — so the binary's glibc floor is compatible with the debian:12 runtime. One line.

The production `docker.yml` image was never affected (it already builds on `ubuntu-22.04`). The `test` job stays on `ubuntu-latest` since it runs the image inside a container, where the host glibc is irrelevant.

## Verification

Re-dispatch the `e2e` workflow on this branch and confirm the test legs get past image startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)