### PR TITLE
ci: smoke-test the pushed docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -100,6 +100,7 @@ jobs:
         run: mv .github/image/bin/oura-Linux-x86_64 .github/image/bin/oura-Linux-amd64
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .github/image
@@ -107,3 +108,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      # Basic smoke test: run the image we just pushed and make sure the binary
+      # actually executes. Pulling by digest selects the amd64 variant on this
+      # runner, which catches runtime breakage like a glibc mismatch against the
+      # debian:12-slim base.
+      - name: Smoke test
+        run: docker run --rm ghcr.io/txpipe/oura@${{ steps.build.outputs.digest }} --version


### PR DESCRIPTION
## Context

The recent e2e failure (`GLIBC_2.39 not found`) was a runtime-only breakage: the image built and pushed fine, and nothing failed until the binary was actually executed. `docker.yml` had no such check, so a broken production image could ship silently.

## What this does

Adds a final **Smoke test** step to the `docker` job: after `build-push`, run the image by digest and invoke `oura --version`.

- `#[clap(version)]` is set on the CLI, so `--version` exits 0 on a healthy binary.
- Pulling `ghcr.io/txpipe/oura@<digest>` selects the **amd64** variant on the runner, so this catches runtime breakage (glibc mismatch, missing shared lib, bad entrypoint) before the workflow goes green.

## Scope / limitations

- Basic by design — it validates the amd64 image only. arm64 isn't exercised (would need QEMU); since both arches are built the same way on `ubuntu-22.04`, amd64 is a representative check.
- Runs on every `docker.yml` invocation (push to `main` and `v*` tags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker image verification in the deployment pipeline with automated smoke testing to ensure container integrity and functionality before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->