### PR TITLE
docs: replace dead mainnet relay in v2 docs and CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -33,7 +33,7 @@ type = "Stdout"
 
 chain peers
 
-**Mainnet** `relays-new.cardano-mainnet.iohk.io:3001`
+**Mainnet** `backbone.mainnet.cardanofoundation.org:3001`
 **Preprod** `preprod-node.world.dev.cardano.org:30000`
 **Preview** `preview-node.world.dev.cardano.org:30002`
 

--- a/docs/v2/sources/n2n.mdx
+++ b/docs/v2/sources/n2n.mdx
@@ -29,12 +29,12 @@ Connecting to a remote Cardano node through tcp sockets:
 ```toml
 [source]
 type = "N2N"
-peers = ["relays-new.cardano-mainnet.iohk.io:3001"]
+peers = ["backbone.mainnet.cardanofoundation.org:3001"]
 ```
 
 ### Public relays
 
-**Mainnet** `relays-new.cardano-mainnet.iohk.io:3001`
+**Mainnet** `backbone.mainnet.cardanofoundation.org:3001`
 
 **Preprod** `preprod-node.world.dev.cardano.org:30000`
 

--- a/docs/v2/usage/daemon.mdx
+++ b/docs/v2/usage/daemon.mdx
@@ -83,7 +83,7 @@ Here's an example configuration file that uses a Node-to-Node source and output 
 ```toml
 [source]
 type = "N2N"
-peers = ["relays-new.cardano-mainnet.iohk.io:3001"]
+peers = ["backbone.mainnet.cardanofoundation.org:3001"]
 
 [intersect]
 type = "Tip"

--- a/docs/v2/usage/dump.mdx
+++ b/docs/v2/usage/dump.mdx
@@ -30,17 +30,17 @@ oura dump [OPTIONS] <socket>
 ### Dump Data From A Remote Relay Node into Stdout
 
 ```sh
-oura dump relays-new.cardano-mainnet.iohk.io:3001 --bearer tcp
+oura dump backbone.mainnet.cardanofoundation.org:3001 --bearer tcp
 ```
 
 ### Dump Data From A Remote Relay Node into Rotating Files
 
 ```sh
-oura dump relays-new.cardano-mainnet.iohk.io:3001 --bearer tcp --output ./mainnet-logs
+oura dump backbone.mainnet.cardanofoundation.org:3001 --bearer tcp --output ./mainnet-logs
 ```
 
 ### Pipe Data From A Remote Relay Node into a new Shell Command
 
 ```sh
-oura dump relays-new.cardano-mainnet.iohk.io:3001 --bearer tcp | grep block
+oura dump backbone.mainnet.cardanofoundation.org:3001 --bearer tcp | grep block
 ```

--- a/docs/v2/usage/watch.mdx
+++ b/docs/v2/usage/watch.mdx
@@ -29,7 +29,7 @@ oura watch [OPTIONS] <socket>
 ### Watch Live Data From A Remote Relay Node
 
 ```sh
-oura watch relays-new.cardano-mainnet.iohk.io:3001 --bearer tcp
+oura watch backbone.mainnet.cardanofoundation.org:3001 --bearer tcp
 ```
 
 ### Watch Live Data From A Local Node Via Unix Socket
@@ -47,7 +47,7 @@ oura watch /opt/cardano/cnode/sockets/node0.socket --bearer unix --magic testnet
 ### Watch Data Starting At A Particular Block
 
 ```sh
-oura watch relays-new.cardano-mainnet.iohk.io:3001 \
+oura watch backbone.mainnet.cardanofoundation.org:3001 \
     --bearer tcp \
     --since 49159253,d034a2d0e4c3076f57368ed59319010c265718f0923057f8ff914a3b6bfd1314
 ```


### PR DESCRIPTION
The v2 docs and `CONTRIBUTING.md` still referenced
`relays-new.cardano-mainnet.iohk.io:3001`, which no longer resolves (NXDOMAIN).
Copy-pasted config snippets and `oura watch` commands using it fail to connect.

Swept it to the live `backbone.mainnet.cardanofoundation.org:3001` relay,
matching the example configs fixed in #939. Hostname-only change.

The v1 docs are maintained on the `lts/v1` branch and are fixed in a separate PR
targeting that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)