### PR TITLE
docs: replace dead mainnet relay in v1 docs

### DIFF
--- a/book/src/advanced/rollback_buffer.md
+++ b/book/src/advanced/rollback_buffer.md
@@ -31,7 +31,7 @@ The min depth is a configurable setting available when running in daemon mode. H
 ```toml
 [source]
 type = "N2N"
-address = ["Tcp", "relays-new.cardano-mainnet.iohk.io:3001"]
+address = ["Tcp", "backbone.mainnet.cardanofoundation.org:3001"]
 magic = "mainnet"
 min_depth = 6
 ```

--- a/book/src/installation/docker.md
+++ b/book/src/installation/docker.md
@@ -15,7 +15,7 @@ The entry-point of the image points to _Oura_ executable. You can pass the same 
 
 ```
 docker run -it ghcr.io/txpipe/oura:latest \
-    watch relays-new.cardano-mainnet.iohk.io:3001 \
+    watch backbone.mainnet.cardanofoundation.org:3001 \
     --bearer tcp
 ```
 

--- a/book/src/sources/n2n.md
+++ b/book/src/sources/n2n.md
@@ -45,7 +45,7 @@ Connecting to a remote Cardano node in mainnet through tcp sockets:
 ```toml
 [source]
 type = "N2N"
-address = ["Tcp", "relays-new.cardano-mainnet.iohk.io:3001"]
+address = ["Tcp", "backbone.mainnet.cardanofoundation.org:3001"]
 magic = "mainnet"
 ```
 
@@ -54,7 +54,7 @@ Connecting to a remote Cardano node in testnet through tcp sockets:
 ```toml
 [source]
 type = "N2N"
-address = ["Tcp", "relays-new.cardano-mainnet.iohk.io:3001"]
+address = ["Tcp", "backbone.mainnet.cardanofoundation.org:3001"]
 magic = "testnet"
 ```
 
@@ -63,7 +63,7 @@ Start reading from a particular point in the chain:
 ```toml
 [source]
 type = "N2C"
-address = ["Tcp", "relays-new.cardano-mainnet.iohk.io:3001"]
+address = ["Tcp", "backbone.mainnet.cardanofoundation.org:3001"]
 magic = "mainnet"
 
 [source.intersect]
@@ -76,7 +76,7 @@ Include all details inside the transaction events:
 ```toml
 [source]
 type = "N2N"
-address = ["Tcp", "relays-new.cardano-mainnet.iohk.io:3001"]
+address = ["Tcp", "backbone.mainnet.cardanofoundation.org:3001"]
 magic = "mainnet"
 
 

--- a/book/src/usage/daemon.md
+++ b/book/src/usage/daemon.md
@@ -90,7 +90,7 @@ Here's an example configuration file that uses a Node-to-Node source and output 
 ```toml
 [source]
 type = "N2N"
-address = ["Tcp", "relays-new.cardano-mainnet.iohk.io:3001"]
+address = ["Tcp", "backbone.mainnet.cardanofoundation.org:3001"]
 magic = "mainnet"
 
 [[filters]]

--- a/book/src/usage/dump.md
+++ b/book/src/usage/dump.md
@@ -29,17 +29,17 @@ oura dump [OPTIONS] <socket>
 ### Dump Data From A Remote Relay Node into Stdout
 
 ```sh
-oura dump relays-new.cardano-mainnet.iohk.io:3001 --bearer tcp
+oura dump backbone.mainnet.cardanofoundation.org:3001 --bearer tcp
 ```
 
 ### Dump Data From A Remote Relay Node into Rotating Files
 
 ```sh
-oura dump relays-new.cardano-mainnet.iohk.io:3001 --bearer tcp --output ./mainnet-logs
+oura dump backbone.mainnet.cardanofoundation.org:3001 --bearer tcp --output ./mainnet-logs
 ```
 
 ### Pipe Data From A Remote Relay Node into a new Shell Command
 
 ```sh
-oura dump relays-new.cardano-mainnet.iohk.io:3001 --bearer tcp | grep block
+oura dump backbone.mainnet.cardanofoundation.org:3001 --bearer tcp | grep block
 ```

--- a/book/src/usage/watch.md
+++ b/book/src/usage/watch.md
@@ -27,7 +27,7 @@ oura watch [OPTIONS] <socket>
 ### Watch Live Data From A Remote Relay Node
 
 ```sh
-oura watch relays-new.cardano-mainnet.iohk.io:3001 --bearer tcp
+oura watch backbone.mainnet.cardanofoundation.org:3001 --bearer tcp
 ```
 
 ### Watch Live Data From A Local Node Via Unix Socket
@@ -45,7 +45,7 @@ oura watch /opt/cardano/cnode/sockets/node0.socket --bearer unix --magic testnet
 ### Watch Data Starting At A Particular Block
 
 ```sh
-oura watch relays-new.cardano-mainnet.iohk.io:3001 \
+oura watch backbone.mainnet.cardanofoundation.org:3001 \
     --bearer tcp \
     --since 49159253,d034a2d0e4c3076f57368ed59319010c265718f0923057f8ff914a3b6bfd1314
 ```


### PR DESCRIPTION
The v1 docs (`book/src/*.md`) referenced `relays-new.cardano-mainnet.iohk.io:3001`,
which no longer resolves (NXDOMAIN). Copy-pasted config snippets and `oura watch`
commands using it fail to connect.

Swept it to the live `backbone.mainnet.cardanofoundation.org:3001` relay.
Hostname-only change. Targets `lts/v1`, where the v1 docs are maintained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)