### PR TITLE
docs: add per-example READMEs and slim the examples showcase

### DIFF
--- a/docs/v2/examples/index.mdx
+++ b/docs/v2/examples/index.mdx
@@ -28,76 +28,63 @@ for the feature flags, or use a Docker image that bundles them.
 
 ## Companion files & setup
 
-Some examples need more than the `daemon.toml`. Check the example's folder before running:
-
-- **Backing service via `docker-compose`** — start it first from the example directory
-  (`docker compose up -d`): `kafka`, `redis`, `rabbitmq`, `elasticsearch`, `postgresql`,
-  `redis_cursor`, `n2c_source`.
-- **Build step** — `wasm_basic` loads `./extract_fee/plugin.wasm`; the Go plugin under
-  `extract_fee/` must be built first (see its README).
-- **Relative output/state created in the working directory** — `into_json`, `parse_cbor` and
-  `file_rotate` write to `./output/`; `mithril` downloads to `./snapshot/`; `file_cursor`
-  writes `my_cursor.json`; `sqlite` writes `./mydatabase.db` and ships an `init.sql` and a
-  `Makefile`.
-- **Has its own README with extra steps** — `metadata_regex_filter`, `postgresql`,
-  `redis_cursor`, `wasm_basic`.
-
-> The `n2c_source` example sets `socket_path = "examples/n2c_source/node/node.socket"`, a path
-> written relative to the **repository root** (unlike the others). Run it from the repo root or
-> edit the path to point at your node socket.
+Some examples need more than the `daemon.toml` — a backing service (`docker compose up -d`),
+a build step, a cargo feature flag, or they write files to the working directory. Each
+example's own `README.md` documents its pipeline, prerequisites, and run command. Check it
+before running.
 
 ## Sources
 
-| Example | What it shows | Setup |
-| :------ | :------------ | :---- |
-| [`n2c_source`](https://github.com/txpipe/oura/tree/main/examples/n2c_source) | Node-to-Client source over a unix socket → Stdout | docker compose · run from repo root |
-| [`hydra`](https://github.com/txpipe/oura/tree/main/examples/hydra) | Hydra head source over a WebSocket → Stdout | needs a running Hydra node |
-| [`mithril`](https://github.com/txpipe/oura/tree/main/examples/mithril) | Mithril snapshot bootstrap with a `Breadcrumbs` intersect | downloads `./snapshot` |
-| [`dolos_source`](https://github.com/txpipe/oura/tree/main/examples/dolos_source) | UTxO RPC (U5C) source against a Dolos/Demeter endpoint | needs a running Dolos (or a hosted U5C endpoint) |
+| Example | What it shows |
+| :------ | :------------ |
+| [`n2c_source`](https://github.com/txpipe/oura/tree/main/examples/n2c_source) | Node-to-Client source over a unix socket → Stdout |
+| [`hydra`](https://github.com/txpipe/oura/tree/main/examples/hydra) | Hydra head source over a WebSocket → Stdout |
+| [`mithril`](https://github.com/txpipe/oura/tree/main/examples/mithril) | Mithril snapshot bootstrap with a `Breadcrumbs` intersect |
+| [`dolos_source`](https://github.com/txpipe/oura/tree/main/examples/dolos_source) | UTxO RPC (U5C) source against a Dolos/Demeter endpoint |
 
 ## Filters & pipelines
 
-| Example | What it shows | Setup |
-| :------ | :------------ | :---- |
-| [`select`](https://github.com/txpipe/oura/tree/main/examples/select) | `SplitBlock` → `ParseCbor` → `Select` by address → Stdout | — |
-| [`metadata_regex_filter`](https://github.com/txpipe/oura/tree/main/examples/metadata_regex_filter) | `Select` matching a metadata label + regex (preprod) → Stdout | see README |
-| [`parse_cbor`](https://github.com/txpipe/oura/tree/main/examples/parse_cbor) | `SplitBlock` → `ParseCbor` → JSONL file output | writes `./output` |
-| [`into_json`](https://github.com/txpipe/oura/tree/main/examples/into_json) | `ParseCbor` → `IntoJson` → compressed JSONL file output | writes `./output` |
-| [`wasm_basic`](https://github.com/txpipe/oura/tree/main/examples/wasm_basic) | Custom `WasmPlugin` filter loaded from a `.wasm` file | build step · `wasm` feature · README |
+| Example | What it shows |
+| :------ | :------------ |
+| [`select`](https://github.com/txpipe/oura/tree/main/examples/select) | `SplitBlock` → `ParseCbor` → `Select` by address → Stdout |
+| [`metadata_regex_filter`](https://github.com/txpipe/oura/tree/main/examples/metadata_regex_filter) | `Select` matching a metadata label + regex (preprod) → Stdout |
+| [`parse_cbor`](https://github.com/txpipe/oura/tree/main/examples/parse_cbor) | `SplitBlock` → `ParseCbor` → JSONL file output |
+| [`into_json`](https://github.com/txpipe/oura/tree/main/examples/into_json) | `ParseCbor` → `IntoJson` → compressed JSONL file output |
+| [`wasm_basic`](https://github.com/txpipe/oura/tree/main/examples/wasm_basic) | Custom `WasmPlugin` filter loaded from a `.wasm` file |
 
 ## Sinks
 
-| Example | What it shows | Setup |
-| :------ | :------------ | :---- |
-| [`stdout`](https://github.com/txpipe/oura/tree/main/examples/stdout) | Legacy v1 events printed to standard output | — |
-| [`webhook_basics`](https://github.com/txpipe/oura/tree/main/examples/webhook_basics) | `WebHook` sink posting events over HTTP | needs an HTTP endpoint |
-| [`kafka`](https://github.com/txpipe/oura/tree/main/examples/kafka) | `Kafka` sink with `ByBlock` partitioning | docker compose · `kafka` feature |
-| [`rabbitmq`](https://github.com/txpipe/oura/tree/main/examples/rabbitmq) | `Rabbitmq` sink | docker compose · `rabbitmq` feature |
-| [`zeromq`](https://github.com/txpipe/oura/tree/main/examples/zeromq) | `Zeromq` PUSH socket sink | `zeromq` feature |
-| [`elasticsearch`](https://github.com/txpipe/oura/tree/main/examples/elasticsearch) | `ElasticSearch` sink | docker compose · `elasticsearch` feature |
-| [`redis`](https://github.com/txpipe/oura/tree/main/examples/redis) | `Redis` streams sink | docker compose · `redis` feature |
-| [`sqlite`](https://github.com/txpipe/oura/tree/main/examples/sqlite) | `SqlDb` sink writing raw CBOR into SQLite | writes `./mydatabase.db` · `sql` feature |
-| [`postgresql`](https://github.com/txpipe/oura/tree/main/examples/postgresql) | `SqlDb` sink targeting PostgreSQL | docker compose · README · `sql` feature |
-| [`file_rotate`](https://github.com/txpipe/oura/tree/main/examples/file_rotate) | `FileRotate` sink writing rotated, compressed JSONL | writes `./output` |
-| [`aws_lambda`](https://github.com/txpipe/oura/tree/main/examples/aws_lambda) | `AwsLambda` sink invoking a function per event | AWS credentials · `aws` feature |
-| [`aws_s3`](https://github.com/txpipe/oura/tree/main/examples/aws_s3) | `AwsS3` sink writing objects | AWS credentials · `aws` feature |
-| [`aws_sqs`](https://github.com/txpipe/oura/tree/main/examples/aws_sqs) | `AwsSqs` sink enqueueing messages | AWS credentials · `aws` feature |
-| [`gcp_pubsub`](https://github.com/txpipe/oura/tree/main/examples/gcp_pubsub) | `GcpPubSub` sink publishing to a topic | GCP credentials · `gcp` feature |
-| [`gcp_cloudfunction`](https://github.com/txpipe/oura/tree/main/examples/gcp_cloudfunction) | `GcpCloudFunction` sink calling a function | GCP credentials · `gcp` feature |
-| [`assert`](https://github.com/txpipe/oura/tree/main/examples/assert) | `Assert` sink used for testing/validation | — |
+| Example | What it shows |
+| :------ | :------------ |
+| [`stdout`](https://github.com/txpipe/oura/tree/main/examples/stdout) | Legacy v1 events printed to standard output |
+| [`webhook_basics`](https://github.com/txpipe/oura/tree/main/examples/webhook_basics) | `WebHook` sink posting events over HTTP |
+| [`kafka`](https://github.com/txpipe/oura/tree/main/examples/kafka) | `Kafka` sink with `ByBlock` partitioning |
+| [`rabbitmq`](https://github.com/txpipe/oura/tree/main/examples/rabbitmq) | `Rabbitmq` sink |
+| [`zeromq`](https://github.com/txpipe/oura/tree/main/examples/zeromq) | `Zeromq` PUSH socket sink |
+| [`elasticsearch`](https://github.com/txpipe/oura/tree/main/examples/elasticsearch) | `ElasticSearch` sink |
+| [`redis`](https://github.com/txpipe/oura/tree/main/examples/redis) | `Redis` streams sink |
+| [`sqlite`](https://github.com/txpipe/oura/tree/main/examples/sqlite) | `SqlDb` sink writing raw CBOR into SQLite |
+| [`postgresql`](https://github.com/txpipe/oura/tree/main/examples/postgresql) | `SqlDb` sink targeting PostgreSQL |
+| [`file_rotate`](https://github.com/txpipe/oura/tree/main/examples/file_rotate) | `FileRotate` sink writing rotated, compressed JSONL |
+| [`aws_lambda`](https://github.com/txpipe/oura/tree/main/examples/aws_lambda) | `AwsLambda` sink invoking a function per event |
+| [`aws_s3`](https://github.com/txpipe/oura/tree/main/examples/aws_s3) | `AwsS3` sink writing objects |
+| [`aws_sqs`](https://github.com/txpipe/oura/tree/main/examples/aws_sqs) | `AwsSqs` sink enqueueing messages |
+| [`gcp_pubsub`](https://github.com/txpipe/oura/tree/main/examples/gcp_pubsub) | `GcpPubSub` sink publishing to a topic |
+| [`gcp_cloudfunction`](https://github.com/txpipe/oura/tree/main/examples/gcp_cloudfunction) | `GcpCloudFunction` sink calling a function |
+| [`assert`](https://github.com/txpipe/oura/tree/main/examples/assert) | `Assert` sink used for testing/validation |
 
 ## Cursors
 
-| Example | What it shows | Setup |
-| :------ | :------------ | :---- |
-| [`file_cursor`](https://github.com/txpipe/oura/tree/main/examples/file_cursor) | Persisting pipeline progress to a `File` cursor | writes `my_cursor.json` |
-| [`redis_cursor`](https://github.com/txpipe/oura/tree/main/examples/redis_cursor) | Persisting pipeline progress to a `Redis` cursor | docker compose · README · `redis` feature |
+| Example | What it shows |
+| :------ | :------------ |
+| [`file_cursor`](https://github.com/txpipe/oura/tree/main/examples/file_cursor) | Persisting pipeline progress to a `File` cursor |
+| [`redis_cursor`](https://github.com/txpipe/oura/tree/main/examples/redis_cursor) | Persisting pipeline progress to a `Redis` cursor |
 
 ## Observability
 
-| Example | What it shows | Setup |
-| :------ | :------------ | :---- |
-| [`metrics`](https://github.com/txpipe/oura/tree/main/examples/metrics) | Exposing a Prometheus metrics endpoint via the `[metrics]` block | — |
+| Example | What it shows |
+| :------ | :------------ |
+| [`metrics`](https://github.com/txpipe/oura/tree/main/examples/metrics) | Exposing a Prometheus metrics endpoint via the `[metrics]` block |
 
 ## As a library
 

--- a/examples/assert/README.md
+++ b/examples/assert/README.md
@@ -1,0 +1,22 @@
+# Assert sink
+
+Run the chain through the `Assert` sink, which validates the event stream against internal
+invariants. Intended for testing and pipeline validation rather than production output.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+  src[N2N source] --> f1[LegacyV1] --> sink[Assert sink]
+```
+
+- **Source** — `N2N`: mainnet relay, starting from the chain tip.
+- **Filters** — `LegacyV1`: maps records to the legacy v1 event model.
+- **Sink** — `Assert`: checks invariants over the event stream and reports violations.
+
+## Run
+
+```sh
+cd examples/assert
+oura daemon --config daemon.toml
+```

--- a/examples/aws_lambda/README.md
+++ b/examples/aws_lambda/README.md
@@ -1,0 +1,32 @@
+# AWS Lambda sink
+
+Decode transactions and invoke an AWS Lambda function once per event.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+  src[N2N source] --> f1[SplitBlock] --> f2[ParseCbor] --> sink[AwsLambda sink]
+```
+
+- **Source** — `N2N`: mainnet relay, starting from the chain tip.
+- **Filters**
+  - `SplitBlock`: breaks each block into individual transactions.
+  - `ParseCbor`: decodes the raw transaction CBOR into structured records.
+- **Sink** — `AwsLambda`: invokes `function_name` in `region` with each event as the payload.
+
+## Prerequisites
+
+- Built with the `aws` feature.
+- AWS credentials available to the process (env vars, profile, or instance role) with
+  permission to invoke the function.
+- Edit `region` and `function_name` in `daemon.toml` to match your function.
+
+## Run
+
+```sh
+cd examples/aws_lambda
+cargo run --features aws --bin oura -- daemon --config daemon.toml
+```
+
+(or `oura daemon --config daemon.toml` with a binary built with the `aws` feature.)

--- a/examples/aws_s3/README.md
+++ b/examples/aws_s3/README.md
@@ -1,0 +1,30 @@
+# AWS S3 sink
+
+Decode transactions and write each one as an object into an S3 bucket.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+  src[N2N source] --> f1[ParseCbor] --> sink[AwsS3 sink]
+```
+
+- **Source** — `N2N`: mainnet relay, starting from the chain tip.
+- **Filters** — `ParseCbor`: decodes the raw transaction CBOR into structured records.
+- **Sink** — `AwsS3`: writes objects under `prefix` in `bucket` (`region`).
+
+## Prerequisites
+
+- Built with the `aws` feature.
+- AWS credentials available to the process (env vars, profile, or instance role) with
+  permission to write to the bucket.
+- Edit `region`, `bucket`, and `prefix` in `daemon.toml` to match your bucket.
+
+## Run
+
+```sh
+cd examples/aws_s3
+cargo run --features aws --bin oura -- daemon --config daemon.toml
+```
+
+(or `oura daemon --config daemon.toml` with a binary built with the `aws` feature.)

--- a/examples/aws_sqs/README.md
+++ b/examples/aws_sqs/README.md
@@ -1,0 +1,33 @@
+# AWS SQS sink
+
+Decode transactions and enqueue each one as a message on an Amazon SQS queue.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+  src[N2N source] --> f1[SplitBlock] --> f2[ParseCbor] --> sink[AwsSqs sink]
+```
+
+- **Source** — `N2N`: mainnet relay, starting from the chain tip.
+- **Filters**
+  - `SplitBlock`: breaks each block into individual transactions.
+  - `ParseCbor`: decodes the raw transaction CBOR into structured records.
+- **Sink** — `AwsSqs`: sends messages to `queue_url` (`region`) with the configured
+  `group_id` (FIFO queues).
+
+## Prerequisites
+
+- Built with the `aws` feature.
+- AWS credentials available to the process (env vars, profile, or instance role) with
+  permission to send to the queue.
+- Edit `region`, `queue_url`, and `group_id` in `daemon.toml` to match your queue.
+
+## Run
+
+```sh
+cd examples/aws_sqs
+cargo run --features aws --bin oura -- daemon --config daemon.toml
+```
+
+(or `oura daemon --config daemon.toml` with a binary built with the `aws` feature.)

--- a/examples/dolos_source/README.md
+++ b/examples/dolos_source/README.md
@@ -1,0 +1,36 @@
+# UTxO RPC (U5C) source
+
+Read the chain from a [UTxO RPC](https://utxorpc.org) (U5C) endpoint — such as a local
+[Dolos](https://github.com/txpipe/dolos) node or a hosted [Demeter](https://demeter.run)
+endpoint — and print events to standard output.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+  src[U5C source] --> sink[Stdout sink]
+```
+
+- **Source** — `U5C`: connects to the gRPC `url`, starting from the chain tip. The
+  `metadata` table carries extra gRPC headers; leave it empty (`{}`) for a local
+  unauthenticated Dolos, or pass an API key for a hosted endpoint
+  (`metadata = { "dmtr-api-key" = "dmtr_..." }`).
+- **Sink** — `Stdout`: prints each event.
+
+## Prerequisites
+
+- A running U5C endpoint (a local Dolos on `localhost:50051`, or a hosted U5C URL).
+- Built with the `u5c` feature (it ships in the released binaries by default).
+
+## Run
+
+```sh
+cd examples/dolos_source
+oura daemon --config daemon.toml
+```
+
+From source:
+
+```sh
+cargo run --features u5c --bin oura -- daemon --config daemon.toml
+```

--- a/examples/elasticsearch/README.md
+++ b/examples/elasticsearch/README.md
@@ -1,0 +1,35 @@
+# Elasticsearch sink
+
+Decode transactions and index them into Elasticsearch.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+  src[N2N source] --> f1[SplitBlock] --> f2[ParseCbor] --> sink[ElasticSearch sink]
+```
+
+- **Source** — `N2N`: mainnet relay, starting from the chain tip.
+- **Filters**
+  - `SplitBlock`: breaks each block into individual transactions.
+  - `ParseCbor`: decodes the raw transaction CBOR into structured records.
+- **Sink** — `ElasticSearch`: indexes documents into `index` on the cluster at `url`
+  (`idempotency = true` makes writes safe to replay).
+
+## Prerequisites
+
+- Built with the `elasticsearch` feature.
+- A running Elasticsearch cluster — a `docker-compose.yaml` is included.
+
+```sh
+docker compose up -d
+```
+
+## Run
+
+```sh
+cd examples/elasticsearch
+cargo run --features elasticsearch --bin oura -- daemon --config daemon.toml
+```
+
+(or `oura daemon --config daemon.toml` with a binary built with the `elasticsearch` feature.)

--- a/examples/file_cursor/README.md
+++ b/examples/file_cursor/README.md
@@ -1,0 +1,28 @@
+# File cursor
+
+Persist pipeline progress to a local file so that, on restart, Oura resumes from the last
+processed point instead of the configured intersect.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+  src[N2N source] --> sink[Stdout sink]
+  sink -. progress .-> cur[(File cursor)]
+```
+
+- **Source** — `N2N`: mainnet relay, starting from the `Point` in `[intersect]` (used only
+  on the first run, before a cursor exists).
+- **Cursor** — `File`: writes the latest position to `my_cursor.json` in the working
+  directory; subsequent runs resume from it.
+- **Sink** — `Stdout`: prints each event.
+
+## Run
+
+```sh
+cd examples/file_cursor
+oura daemon --config daemon.toml
+```
+
+Stop and restart the daemon to see it resume from `my_cursor.json` rather than the intersect
+point.

--- a/examples/file_rotate/README.md
+++ b/examples/file_rotate/README.md
@@ -1,0 +1,27 @@
+# File Rotate sink
+
+Write legacy v1 events to rotated, compressed JSONL files on disk.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+  src[N2N source] --> f1[LegacyV1] --> sink[FileRotate sink]
+```
+
+- **Source** — `N2N`: mainnet relay, starting from the `Point` in `[intersect]`.
+- **Filters** — `LegacyV1`: maps records to the legacy v1 event model
+  (`include_transaction_details = true`).
+- **Sink** — `FileRotate`: writes JSONL to `./output/logs.jsonl`, rotating across up to 5
+  compressed files of 5 MB each.
+
+See the [FileRotate sink docs](../../docs/v2/sinks/file_rotate.mdx).
+
+## Run
+
+```sh
+cd examples/file_rotate
+oura daemon --config daemon.toml
+```
+
+Output is written to `./output/` in the working directory.

--- a/examples/gcp_cloudfunction/README.md
+++ b/examples/gcp_cloudfunction/README.md
@@ -1,0 +1,33 @@
+# GCP Cloud Function sink
+
+Decode transactions and call a Google Cloud Function once per event.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+  src[N2N source] --> f1[SplitBlock] --> f2[ParseCbor] --> sink[GcpCloudFunction sink]
+```
+
+- **Source** — `N2N`: mainnet relay, starting from the chain tip.
+- **Filters**
+  - `SplitBlock`: breaks each block into individual transactions.
+  - `ParseCbor`: decodes the raw transaction CBOR into structured records.
+- **Sink** — `GcpCloudFunction`: invokes the function at `url`
+  (`authentication = true` attaches a Google-issued identity token).
+
+## Prerequisites
+
+- Built with the `gcp` feature.
+- GCP credentials available to the process (e.g. `GOOGLE_APPLICATION_CREDENTIALS`) with
+  permission to invoke the function.
+- Edit `url` in `daemon.toml` to point at your deployed function.
+
+## Run
+
+```sh
+cd examples/gcp_cloudfunction
+cargo run --features gcp --bin oura -- daemon --config daemon.toml
+```
+
+(or `oura daemon --config daemon.toml` with a binary built with the `gcp` feature.)

--- a/examples/gcp_pubsub/README.md
+++ b/examples/gcp_pubsub/README.md
@@ -1,0 +1,32 @@
+# GCP Pub/Sub sink
+
+Decode transactions and publish each one to a Google Cloud Pub/Sub topic.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+  src[N2N source] --> f1[SplitBlock] --> f2[ParseCbor] --> sink[GcpPubSub sink]
+```
+
+- **Source** — `N2N`: mainnet relay, starting from the chain tip.
+- **Filters**
+  - `SplitBlock`: breaks each block into individual transactions.
+  - `ParseCbor`: decodes the raw transaction CBOR into structured records.
+- **Sink** — `GcpPubSub`: publishes events to `topic`.
+
+## Prerequisites
+
+- Built with the `gcp` feature.
+- GCP credentials available to the process (e.g. `GOOGLE_APPLICATION_CREDENTIALS`) with
+  permission to publish to the topic.
+- Edit `topic` in `daemon.toml` to match your topic.
+
+## Run
+
+```sh
+cd examples/gcp_pubsub
+cargo run --features gcp --bin oura -- daemon --config daemon.toml
+```
+
+(or `oura daemon --config daemon.toml` with a binary built with the `gcp` feature.)

--- a/examples/hydra/README.md
+++ b/examples/hydra/README.md
@@ -1,0 +1,33 @@
+# Hydra source
+
+Stream transactions from a [Hydra](https://hydra.family) head over its WebSocket API and
+print them to standard output.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+  src[Hydra source] --> sink[Stdout sink]
+```
+
+- **Source** — `Hydra`: connects to the head's `ws_url` (network `magic`), starting from
+  `Origin`.
+- **Sink** — `Stdout`: prints each event.
+
+## Prerequisites
+
+- A running Hydra node exposing its WebSocket API (default `ws://127.0.0.1:4001`).
+- Built with the `hydra` feature.
+
+## Run
+
+```sh
+cd examples/hydra
+oura daemon --config daemon.toml
+```
+
+From source:
+
+```sh
+cargo run --features hydra --bin oura -- daemon --config daemon.toml
+```

--- a/examples/into_json/README.md
+++ b/examples/into_json/README.md
@@ -1,0 +1,28 @@
+# Into JSON to JSONL files
+
+Decode transactions and convert the parsed records into JSON before writing them to rotated,
+compressed JSONL files. Builds on the `parse_cbor` example by adding the `IntoJson` filter.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+  src[N2N source] --> f1[SplitBlock] --> f2[ParseCbor] --> f3[IntoJson] --> sink[FileRotate sink]
+```
+
+- **Source** — `N2N`: mainnet relay, starting from the `Point` in `[intersect]`.
+- **Filters**
+  - `SplitBlock`: breaks each block into individual transactions.
+  - `ParseCbor`: decodes the raw transaction CBOR into structured records.
+  - `IntoJson`: turns the parsed records into JSON payloads.
+- **Sink** — `FileRotate`: writes JSONL to `./output/logs.jsonl`, rotating across up to 5
+  compressed files of 5 MB each.
+
+## Run
+
+```sh
+cd examples/into_json
+oura daemon --config daemon.toml
+```
+
+Output is written to `./output/` in the working directory.

--- a/examples/kafka/README.md
+++ b/examples/kafka/README.md
@@ -1,0 +1,35 @@
+# Kafka sink
+
+Decode transactions and publish them to an Apache Kafka topic, partitioned by block.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+  src[N2N source] --> f1[SplitBlock] --> f2[ParseCbor] --> sink[Kafka sink]
+```
+
+- **Source** — `N2N`: mainnet relay, starting from the chain tip.
+- **Filters**
+  - `SplitBlock`: breaks each block into individual transactions.
+  - `ParseCbor`: decodes the raw transaction CBOR into structured records.
+- **Sink** — `Kafka`: publishes to `topic` on the configured `brokers`, using `ByBlock`
+  partitioning.
+
+## Prerequisites
+
+- Built with the `kafka` feature.
+- A running Kafka broker — a `docker-compose.yaml` is included.
+
+```sh
+docker compose up -d
+```
+
+## Run
+
+```sh
+cd examples/kafka
+cargo run --features kafka --bin oura -- daemon --config daemon.toml
+```
+
+(or `oura daemon --config daemon.toml` with a binary built with the `kafka` feature.)

--- a/examples/metadata_regex_filter/README.md
+++ b/examples/metadata_regex_filter/README.md
@@ -1,6 +1,23 @@
-# Metadata Regex Filter Example
+# Metadata regex filter
 
-Filter transactions by metadata content using regex patterns.
+Keep only the transactions whose metadata matches a regular expression, and print them to
+standard output. Runs against preprod.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+  src[N2N source] --> f1[SplitBlock] --> f2[ParseCbor] --> f3[Select] --> sink[Stdout sink]
+```
+
+- **Source** — `N2N`: preprod relay, starting from the chain tip.
+- **Filters**
+  - `SplitBlock`: breaks each block into individual transactions.
+  - `ParseCbor`: decodes the raw transaction CBOR into structured records.
+  - `Select`: keeps records whose metadata at `label = 674` has text matching the `regex`
+    predicate. The search recurses through nested arrays and maps; omit `label` to search
+    across all metadata.
+- **Sink** — `Stdout`: prints the matching transactions.
 
 ## Configuration
 
@@ -13,30 +30,25 @@ skip_uncertain = false
 label = 674
 
 [filters.predicate.match.metadata.value.text]
-regex = "testing regex"
+regex = "Hello World"
 ```
 
-## Running
-
-```bash
-oura daemon --config ./daemon.toml
-```
-
-## Features
-
-- **Recursive search**: Automatically searches through nested arrays and maps
-- **Flexible patterns**: Use standard regex syntax
-- **Optional label**: Omit `label` field to search across all metadata
-
-## Common Patterns
+Common regex patterns:
 
 ```toml
-regex = "(?i)keyword"          # Case-insensitive
-regex = "^MyApp:"               # Starts with
-regex = "payment|donation"      # Multiple keywords
+regex = "(?i)keyword"      # case-insensitive
+regex = "^MyApp:"           # starts with
+regex = "payment|donation"  # multiple keywords
 ```
 
-## See Also
+## Run
 
-- [Select Filter Documentation](../../docs/v2/filters/select.mdx)
-- [CIP-20 Specification](https://cips.cardano.org/cips/cip20/)
+```sh
+cd examples/metadata_regex_filter
+oura daemon --config daemon.toml
+```
+
+## See also
+
+- [Select filter docs](../../docs/v2/filters/select.mdx)
+- [CIP-20 specification](https://cips.cardano.org/cips/cip20/)

--- a/examples/metrics/README.md
+++ b/examples/metrics/README.md
@@ -1,0 +1,28 @@
+# Metrics endpoint
+
+Expose pipeline metrics over a Prometheus-compatible HTTP endpoint by enabling the
+`[metrics]` block. The pipeline itself does no useful work — it uses the `Noop` sink so the
+focus stays on observability.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+  src[N2N source] --> sink[Noop sink]
+  src -. metrics .-> m([Prometheus endpoint])
+  sink -. metrics .-> m
+```
+
+- **Source** — `N2N`: mainnet relay, starting from the `Point` in `[intersect]`.
+- **Sink** — `Noop`: discards events.
+- **Metrics** — the `[metrics]` block starts a Prometheus endpoint reporting throughput,
+  chain position, and other counters.
+
+## Run
+
+```sh
+cd examples/metrics
+oura daemon --config daemon.toml
+```
+
+Then scrape the metrics endpoint (default `http://localhost:9186/metrics`).

--- a/examples/mithril/README.md
+++ b/examples/mithril/README.md
@@ -1,0 +1,40 @@
+# Mithril bootstrap
+
+Bootstrap a pipeline by downloading a [Mithril](https://mithril.network) snapshot, then
+resume from a `Breadcrumbs` intersect. Useful for quickly syncing recent chain state without
+replaying from origin.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+  src[Mithril source] --> sink[Stdout sink]
+```
+
+- **Source** — `Mithril`: downloads a verified snapshot from the configured `aggregator`
+  into `./snapshot`, validating it against `genesis_key`
+  (set `skip_validation = true` to skip verification).
+- **Intersect** — `Breadcrumbs`: a list of recent points to resume from after the snapshot
+  is restored.
+- **Sink** — `Stdout`: prints each event.
+
+> This example targets the Mithril **pre-release-preview** aggregator.
+
+## Prerequisites
+
+- Built with the `mithril` feature.
+
+## Run
+
+```sh
+cd examples/mithril
+oura daemon --config daemon.toml
+```
+
+From source:
+
+```sh
+cargo run --features mithril --bin oura -- daemon --config daemon.toml
+```
+
+The snapshot is downloaded to `./snapshot/` in the working directory.

--- a/examples/n2c_source/README.md
+++ b/examples/n2c_source/README.md
@@ -1,0 +1,33 @@
+# Node-to-Client source
+
+Read the chain directly from a local Cardano node over a Node-to-Client (N2C) Unix socket and
+print events to standard output.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+  src[N2C source] --> sink[Stdout sink]
+```
+
+- **Source** — `N2C`: connects to the node's `socket_path`, starting from the chain tip.
+- **Sink** — `Stdout`: prints each event.
+
+## Companion files
+
+A `docker-compose.yml` is included to spin up a local node that exposes the socket.
+
+```sh
+docker compose up -d
+```
+
+## Run
+
+> ⚠️ Unlike the other examples, `socket_path` in `daemon.toml` is written relative to the
+> **repository root** (`examples/n2c_source/node/node.socket`). Run this example from the repo
+> root, or edit the path to point at your node socket.
+
+```sh
+# from the repository root
+oura daemon --config examples/n2c_source/daemon.toml
+```

--- a/examples/parse_cbor/README.md
+++ b/examples/parse_cbor/README.md
@@ -1,0 +1,27 @@
+# Parse CBOR to JSONL files
+
+Split blocks into transactions, decode their CBOR, and write the parsed records to rotated,
+compressed JSONL files on disk.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+  src[N2N source] --> f1[SplitBlock] --> f2[ParseCbor] --> sink[FileRotate sink]
+```
+
+- **Source** — `N2N`: mainnet relay, starting from the `Point` in `[intersect]`.
+- **Filters**
+  - `SplitBlock`: breaks each block into individual transactions.
+  - `ParseCbor`: decodes the raw transaction CBOR into structured records.
+- **Sink** — `FileRotate`: writes JSONL to `./output/logs.jsonl`, rotating across up to 5
+  compressed files of 5 MB each.
+
+## Run
+
+```sh
+cd examples/parse_cbor
+oura daemon --config daemon.toml
+```
+
+Output is written to `./output/` in the working directory.

--- a/examples/rabbitmq/README.md
+++ b/examples/rabbitmq/README.md
@@ -1,0 +1,31 @@
+# RabbitMQ sink
+
+Publish chain events to a RabbitMQ exchange over AMQP.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+  src[N2N source] --> sink[Rabbitmq sink]
+```
+
+- **Source** — `N2N`: mainnet relay, starting from the chain tip.
+- **Sink** — `Rabbitmq`: publishes events to `exchange` on the broker at `url`.
+
+## Prerequisites
+
+- Built with the `rabbitmq` feature.
+- A running RabbitMQ broker — a `docker-compose.yaml` is included.
+
+```sh
+docker compose up -d
+```
+
+## Run
+
+```sh
+cd examples/rabbitmq
+cargo run --features rabbitmq --bin oura -- daemon --config daemon.toml
+```
+
+(or `oura daemon --config daemon.toml` with a binary built with the `rabbitmq` feature.)

--- a/examples/redis/README.md
+++ b/examples/redis/README.md
@@ -1,0 +1,34 @@
+# Redis sink
+
+Decode transactions and push them to a Redis stream.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+  src[N2N source] --> f1[SplitBlock] --> f2[ParseCbor] --> sink[Redis sink]
+```
+
+- **Source** — `N2N`: mainnet relay, starting from the chain tip.
+- **Filters**
+  - `SplitBlock`: breaks each block into individual transactions.
+  - `ParseCbor`: decodes the raw transaction CBOR into structured records.
+- **Sink** — `Redis`: appends events to `stream_name` on the Redis instance at `url`.
+
+## Prerequisites
+
+- Built with the `redis` feature.
+- A running Redis instance — a `docker-compose.yaml` is included.
+
+```sh
+docker compose up -d
+```
+
+## Run
+
+```sh
+cd examples/redis
+cargo run --features redis --bin oura -- daemon --config daemon.toml
+```
+
+(or `oura daemon --config daemon.toml` with a binary built with the `redis` feature.)

--- a/examples/redis_cursor/README.md
+++ b/examples/redis_cursor/README.md
@@ -1,22 +1,55 @@
 # Redis cursor
 
-This example shows you how to persits the cursor information on a Redis cluster.
+Persist pipeline progress to a Redis instance so that, on restart, Oura resumes from the last
+processed point. Reads preprod over a Node-to-Client socket and prints events to standard
+output.
 
-The `daemon.toml` includes the `[cursor]` section that has `type` set to `Redis`, `key` is the key on the redis cluster where to dump the information, and `url` the connection string to connect with Redis.
+## Pipeline
 
-To run the example:
+```mermaid
+flowchart LR
+  src[N2C source] --> sink[Stdout sink]
+  sink -. progress .-> cur[(Redis cursor)]
+```
 
-* Set up [Demeter CLI](https://docs.demeter.run/cli).
-* On a different terminal but same path run `dmtr ports tunnel`.
-  Chose the `node` option, followed by the `preprod` network and the `stable` version. Finally, mount the socket on `./socket`.
-* `docker compose up -d` to spin up the Redis instance.
-* ```sh
-  cargo run --bin oura --features redis daemon --config daemon.toml
-  ```
+- **Source** — `N2C`: connects to the node socket at `./socket` (preprod), starting from
+  `Origin` on the first run.
+- **Cursor** — `Redis`: flushes the latest position to `key` on the instance at `url` every
+  `flush_interval` seconds; subsequent runs resume from it.
+- **Sink** — `Stdout`: prints each event.
 
-In order to see cursor information on the Redis you can do the following.
+## Prerequisites
+
+- Built with the `redis` feature.
+- A preprod node socket and a running Redis instance (see setup below).
+
+## Setup
+
+1. Provide a preprod node socket at `./socket`. Using the
+   [Demeter CLI](https://docs.demeter.run/cli):
+
+   ```sh
+   dmtr ports tunnel
+   ```
+
+   Choose `node` → `preprod` → `stable`, and mount the socket on `./socket`.
+
+2. Start Redis:
+
+   ```sh
+   docker compose up -d
+   ```
+
+## Run
 
 ```sh
-$ docker exec -it redis redis-cli
+cd examples/redis_cursor
+cargo run --bin oura --features redis daemon --config daemon.toml
+```
+
+Inspect the stored cursor:
+
+```sh
+docker exec -it redis redis-cli
 127.0.0.1:6379> GET key
 ```

--- a/examples/select/README.md
+++ b/examples/select/README.md
@@ -1,0 +1,27 @@
+# Select by address
+
+Keep only the transactions that touch a specific address and print them to standard output.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+  src[N2N source] --> f1[SplitBlock] --> f2[ParseCbor] --> f3[Select] --> sink[Stdout sink]
+```
+
+- **Source** — `N2N`: mainnet relay, starting from the `Point` in `[intersect]`.
+- **Filters**
+  - `SplitBlock`: breaks each block into individual transactions.
+  - `ParseCbor`: decodes the raw transaction CBOR into structured records.
+  - `Select`: keeps only records matching the `predicate` address
+    (`skip_uncertain = true` drops records it cannot confidently evaluate).
+- **Sink** — `Stdout`: prints the matching transactions.
+
+See the [Select filter docs](../../docs/v2/filters/select.mdx).
+
+## Run
+
+```sh
+cd examples/select
+oura daemon --config daemon.toml
+```

--- a/examples/sqlite/README.md
+++ b/examples/sqlite/README.md
@@ -1,6 +1,6 @@
-# PostgreSQL sink
+# SQLite sink
 
-Split blocks into transactions and persist their raw CBOR into a PostgreSQL database using
+Split blocks into transactions and persist their raw CBOR into a local SQLite database using
 templated SQL statements.
 
 ## Pipeline
@@ -13,37 +13,29 @@ flowchart LR
 - **Source** — `N2N`: mainnet relay, starting from the `Point` in `[intersect]`.
 - **Filters** — `SplitBlock`: breaks each block into individual transactions.
 - **Sink** — `SqlDb`: runs the `apply_template` / `undo_template` / `reset_template`
-  statements against the `postgres://` connection, storing each transaction's slot and CBOR.
+  statements against `sqlite:./mydatabase.db`, storing each transaction's slot and CBOR.
   Rollbacks and resets are handled by the undo/reset templates.
 
 ## Companion files
 
-- `docker-compose.yml` — a local PostgreSQL instance.
 - `init.sql` — creates the `txs` table (and slot index) the templates write to.
+- `Makefile` — `make create_db` runs `init.sql` against `mydatabase.db`.
+
+```sh
+make create_db          # or: sqlite3 mydatabase.db < init.sql
+```
 
 ## Prerequisites
 
 - Built with the `sql` feature.
 
-## Setup
-
-1. Start PostgreSQL:
-
-   ```sh
-   docker compose up -d
-   ```
-
-2. Create the table:
-
-   ```sh
-   psql -h localhost -p 5432 -U postgres -f init.sql
-   ```
-
 ## Run
 
 ```sh
-cd examples/postgresql
+cd examples/sqlite
 cargo run --features sql --bin oura -- daemon --config daemon.toml
 ```
 
 (or `oura daemon --config daemon.toml` with a binary built with the `sql` feature.)
+
+The database is written to `./mydatabase.db` in the working directory.

--- a/examples/stdout/README.md
+++ b/examples/stdout/README.md
@@ -1,0 +1,24 @@
+# Stdout
+
+The simplest end-to-end pipeline: follow the mainnet chain from a fixed point and print
+each event to standard output as legacy v1 JSON.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+  src[N2N source] --> f1[LegacyV1] --> sink[Stdout sink]
+```
+
+- **Source** — `N2N`: connects to a mainnet relay over node-to-node, starting from the
+  `Point` declared in `[intersect]`.
+- **Filters** — `LegacyV1`: maps records to the legacy v1 event model
+  (`include_transaction_details = true` expands transaction bodies).
+- **Sink** — `Stdout`: prints one JSON event per line.
+
+## Run
+
+```sh
+cd examples/stdout
+oura daemon --config daemon.toml
+```

--- a/examples/wasm_basic/README.md
+++ b/examples/wasm_basic/README.md
@@ -1,35 +1,47 @@
-# WASM Basic
+# WASM plugin filter
 
-This example shows how to build a custom Oura plugin using Golang.
+Run a custom WASM filter built in Go. The plugin under `./extract_fee` extracts the fee value
+of each transaction, so the events printed to stdout are the per-transaction fees.
 
-The code under `./extract_fee` contains the Golang source code for the plugin. The scope of this very basic plugin is to extract the fee value of each transaction.
+## Pipeline
 
-## Requirements
+```mermaid
+flowchart LR
+  src[N2N source] --> f1[SplitBlock] --> f2[ParseCbor] --> f3[WasmPlugin] --> sink[Stdout sink]
+```
 
-- [tinygo](https://tinygo.org/getting-started/install/)
+- **Source** — `N2N`: mainnet relay, starting from the `Point` in `[intersect]`.
+- **Filters**
+  - `SplitBlock`: breaks each block into individual transactions.
+  - `ParseCbor`: decodes the raw transaction CBOR into structured records.
+  - `WasmPlugin`: loads `./extract_fee/plugin.wasm` and transforms each record (here,
+    extracting the fee).
+- **Sink** — `Stdout`: prints the plugin's output.
 
-> While the core Go toolchain has support to target WebAssembly, we find tinygo to work well for plug-in code.
+## Prerequisites
 
-## Procedure
+- Built with the `wasm` feature.
+- [tinygo](https://tinygo.org/getting-started/install/) to compile the plugin.
 
-1. Build the plugin
+> The core Go toolchain can target WebAssembly, but tinygo works well for plugin code. The Go
+> code uses the [extism](https://github.com/extism) plugin system; see the
+> [go-pdk docs](https://github.com/extism/go-pdk) for more.
 
-Run the following command from inside the `./extract_fee` directory to compile the Golang source into a WASM module using tinigo.
+## Setup
+
+Build the plugin from inside `./extract_fee` — this produces the `plugin.wasm` that
+`daemon.toml` already points at:
 
 ```sh
+cd extract_fee
 tinygo build -o plugin.wasm -target wasi main.go
 ```
 
-The Golang code relies on a plugin system called [extism](https://github.com/extism) that provides several extra features which are not reflected in this example. To read more about how to use Extism in go, refer to the [official docs](https://github.com/extism/go-pdk).
-
-1. Run Oura using the plugin
-
-Run Oura using the `daemon.toml` config in this example that already points to the compiled WASM module generated in the previous step.
+## Run
 
 ```sh
-cargo run --features wasm --bin oura -- daemon --config ./daemon.toml
+cd examples/wasm_basic
+cargo run --features wasm --bin oura -- daemon --config daemon.toml
 ```
 
-> Note that wasm plugins require the Cargo feature flag named `wasm`
-
-You should notice that the events piped in stdout show numbers that represent the fees of each transaction processed.
+(or `oura daemon --config daemon.toml` with a binary built with the `wasm` feature.)

--- a/examples/webhook_basics/README.md
+++ b/examples/webhook_basics/README.md
@@ -1,0 +1,30 @@
+# Webhook sink
+
+Post chain events to an HTTP endpoint using the `WebHook` sink.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+  src[N2N source] --> f1[SplitBlock] --> f2[ParseCbor] --> sink[WebHook sink]
+```
+
+- **Source** — `N2N`: mainnet relay, starting from the `Point` in `[intersect]`.
+- **Filters**
+  - `SplitBlock`: breaks each block into individual transactions.
+  - `ParseCbor`: decodes the raw transaction CBOR into structured records.
+- **Sink** — `WebHook`: sends an HTTP request per event to the configured `url`
+  (default `http://localhost:8080`).
+
+See the [WebHook sink docs](../../docs/v2/sinks/webhook.mdx).
+
+## Prerequisites
+
+- An HTTP endpoint to receive the requests. Edit `url` in `daemon.toml` to point at it.
+
+## Run
+
+```sh
+cd examples/webhook_basics
+oura daemon --config daemon.toml
+```

--- a/examples/zeromq/README.md
+++ b/examples/zeromq/README.md
@@ -1,0 +1,27 @@
+# ZeroMQ sink
+
+Stream chain events out over a ZeroMQ PUSH socket.
+
+## Pipeline
+
+```mermaid
+flowchart LR
+  src[N2N source] --> sink[Zeromq sink]
+```
+
+- **Source** — `N2N`: mainnet relay, starting from the chain tip.
+- **Sink** — `Zeromq`: pushes events to the socket bound at `url`.
+
+## Prerequisites
+
+- Built with the `zeromq` feature.
+- A ZeroMQ PULL consumer connected to the configured `url` to receive the messages.
+
+## Run
+
+```sh
+cd examples/zeromq
+cargo run --features zeromq --bin oura -- daemon --config daemon.toml
+```
+
+(or `oura daemon --config daemon.toml` with a binary built with the `zeromq` feature.)


### PR DESCRIPTION
## What

Every runnable example under `examples/` now ships a brief `README.md` covering its **scope**, **pipeline** (as a mermaid flowchart), **prerequisites**, and **run command**.

- **24 new READMEs** — `assert`, `aws_lambda`, `aws_s3`, `aws_sqs`, `dolos_source`, `elasticsearch`, `file_cursor`, `file_rotate`, `gcp_cloudfunction`, `gcp_pubsub`, `hydra`, `into_json`, `kafka`, `metrics`, `mithril`, `n2c_source`, `parse_cbor`, `redis`, `select`, `sqlite`, `stdout`, `webhook_basics`, `zeromq`, `rabbitmq`.
- **4 existing READMEs** reshaped to the same template, preserving their unique steps — `postgresql` (psql/init.sql), `redis_cursor` (Demeter tunnel), `metadata_regex_filter` (regex patterns), `wasm_basic` (tinygo build).
- Left untouched: `examples/lib/` (its own tailored README) and `examples/_deprecated/*`.

Each pipeline diagram was verified against the example's actual `daemon.toml`, and cargo feature flags against `Cargo.toml`. Run commands use the installed-binary form, plus `cargo run --features <feat>` where a feature flag is required.

## Showcase doc cleanup

With the per-example READMEs now serving as the detail pages behind the showcase links, `docs/v2/examples/index.mdx`:

- collapses the duplicated **"Companion files & setup"** section to a one-line pointer to each example's README;
- drops the **"Setup"** column from all five tables, leaving a clean **Example | What it shows** catalog.

The "Running an example" guidance, the inline TOML recipes, and the "As a library" section are kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added comprehensive README files for all example projects, each documenting pipeline architecture, prerequisites, and run instructions
* Reorganized main examples index page with simplified table structure, directing users to individual example documentation
* Standardized example documentation format across all pipelines using consistent sections, Mermaid diagrams, and clear setup guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->