### PR TITLE
docs: correct opt-in build notes for kafka and mithril

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,12 +32,14 @@ kafka = ["dep:kafka", "openssl"]
 # compile a custom flavor. The bundle is fully pure-Rust TLS (rustls, no system
 # OpenSSL). Measured stripped size (dist profile): ~37 MB.
 #
-# Kept OUT of the default binary (require a source build) because each needs a
-# special build environment incompatible with portable cross-target releases:
-#   - kafka: its only TLS backend is openssl-sys; would force vendored OpenSSL
-#            (and NASM on windows-msvc) into every release build
-#   - zeromq: links a system libzmq (no vendored build)
-#   - mithril: pulls gmp-mpfr-sys (GMP C lib); unsupported on windows-msvc
+# Kept OUT of the default binary (available via a source build) to keep the
+# release lean and free of system/C dependencies:
+#   - kafka: its only TLS backend is openssl-sys; bundling it would pull a
+#            vendored OpenSSL build into the otherwise pure-Rust-TLS binary
+#   - zeromq: dynamically links a system libzmq (a runtime dependency), so it
+#             can't ship in a portable prebuilt binary
+#   - mithril: builds everywhere, but pulls a heavy GMP/blst C-crypto toolchain
+#              (gmp-mpfr-sys, blst, rug) that bloats binary size and build time
 #   - wasm: extism/wasmtime; pure-Rust but ~+14 MB and itself a plugin runtime
 [package.metadata.dist]
 features = ["u5c", "elasticsearch", "hydra", "redis", "rabbitmq", "sql", "gcp", "aws"]

--- a/docs/v2/installation/binary_release.mdx
+++ b/docs/v2/installation/binary_release.mdx
@@ -12,11 +12,11 @@ The pre-built binaries are **batteries-included**: every integration that builds
 - **Sinks:** terminal, stdout, file rotate, webhook, Elasticsearch, Redis, RabbitMQ, SQL (SQLite / Postgres), AWS (SQS / Lambda / S3), GCP (Pub/Sub / Cloud Functions)
 - **Filters:** all built-in filters (select, split block, JSON, legacy v1, etc.)
 
-Only integrations that need a special build environment are left out and require a [source build](/v2/installation/from_source):
+A few integrations are left out to keep the binary lean and free of system/C dependencies, and require a [source build](/v2/installation/from_source):
 
-- **`kafka`** — its only TLS backend is OpenSSL (a system C library), unlike the rest of the binary which is pure-Rust TLS
-- **`zeromq`** — links a system `libzmq`
-- **`mithril`** — pulls the GMP C library, which is unsupported on Windows (MSVC)
+- **`kafka`** — its only TLS backend is OpenSSL; bundling it would pull a vendored OpenSSL build into the otherwise pure-Rust-TLS binary
+- **`zeromq`** — dynamically links a system `libzmq` at runtime, so it can't ship in a portable prebuilt binary
+- **`mithril`** — pulls a heavy GMP/blst C-crypto toolchain that significantly increases binary size and build time
 - **`wasm`** — the WASM plugin runtime (large, and itself a plugin host)
 
 ## Install via shell script

--- a/docs/v2/installation/from_source.mdx
+++ b/docs/v2/installation/from_source.mdx
@@ -29,11 +29,12 @@ cargo install --path . --features kafka,mithril
 
 | Feature | Prerequisite |
 |---------|--------------|
-| `kafka` | OpenSSL (its only TLS backend); your platform's OpenSSL dev libraries |
+| `kafka` | builds a vendored OpenSSL (its only TLS backend): a C compiler and Perl |
 | `zeromq` | a system `libzmq` (install via your OS package manager) |
-| `mithril` | a GMP toolchain; **not supported on Windows MSVC** |
+| `mithril` | none, but builds a heavy GMP/blst C-crypto toolchain (slow build) |
 | `wasm` | none (pure Rust), but adds a large WASM runtime |
 
 :::note
-Avoid `--all-features`: it enables `zeromq` and `mithril`, which fail without the prerequisites above.
+`--all-features` requires a system `libzmq` (for `zeromq`) and builds mithril's
+heavy C-crypto toolchain, so it is slow and best avoided unless you need it.
 :::


### PR DESCRIPTION
Follow-up to #944 fixing two inaccurate notes about the opt-in (source-build) integrations. **Docs/comments only — no behaviour change.**

- **mithril** — #944 said it's "unsupported on Windows MSVC". The green `cargo check --all-features` Windows CI check disproves that: mithril's GMP/blst C-crypto crates build and statically link on windows-msvc. It's opt-in because it's a heavy C toolchain (larger binary, much longer build), not for portability.
- **kafka** — now that the `kafka` feature pulls a vendored OpenSSL build, opt-in builds need a C compiler + Perl, not the platform's system OpenSSL dev libraries.
- Also reworded the `zeromq` note to make the real reason explicit: it dynamically links a system `libzmq` at runtime, so it can't ship in a portable prebuilt binary.

Touches the `[package.metadata.dist]` comment in `Cargo.toml` and the two installation docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified which integrations (Kafka, ZeroMQ, Mithril) are excluded from portable binary releases and their system/C dependency constraints.
  * Updated build prerequisites documentation with improved explanations of required toolchains and dependencies for building from source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->