### PR TITLE
chore: update cargo-dist, drop self-updater and PR release dry-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
-  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
@@ -66,7 +65,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.29.0/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.3/cargo-dist-installer.sh | sh"
       - name: Cache dist
         uses: actions/upload-artifact@v4
         with:
@@ -223,8 +222,8 @@ jobs:
       - plan
       - build-local-artifacts
       - build-global-artifacts
-    # Only run if we're "publishing", and only if local and global didn't fail (skipped is fine)
-    if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
+    # Only run if we're "publishing", and only if plan, local and global didn't fail (skipped is fine)
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: "ubuntu-22.04"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -4,7 +4,7 @@ members = ["cargo:."]
 # Config for 'dist'
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.29.0"
+cargo-dist-version = "0.30.3"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
@@ -16,7 +16,10 @@ install-path = "CARGO_HOME"
 # The preferred Rust toolchain to use in CI (rustup toolchain syntax)
 rust-toolchain-version = "1.89"
 # Whether to install an updater program
-install-updater = true
+install-updater = false
+# Don't run the release dry-run on pull requests; only fire on version tags.
+# (PR validation lives in ci.yml.)
+pr-run-mode = "skip"
 # A GitHub repo to push Homebrew formulas to
 tap = "txpipe/homebrew-tap"
 # Publish jobs to run in CI


### PR DESCRIPTION
## What

Bump cargo-dist to **0.30.3** and adjust its config in `dist-workspace.toml`:

- **`install-updater = false`** — stop bundling the `axoupdate` self-updater in the generated installers.
- **`pr-run-mode = "skip"`** — don't run the release dry-run on pull requests. The release workflow (`release.yml`) now fires only on version tags; PR validation already lives in `ci.yml`.

`.github/workflows/release.yml` is regenerated from `dist-workspace.toml` to match.

## Why

- The self-updater isn't wanted for this distribution.
- The `dist plan` dry-run ran on every PR for no benefit — `ci.yml` (fmt/clippy/test/check) is the real PR gate.

## Verification

- `dist generate --check` is clean (TOML ↔ YAML in sync).
- `dist plan` succeeds: all four targets and all installers (shell, powershell, npm, homebrew) present, no updater artifact.
- `release.yml` `on:` block now contains only `push: tags:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation configuration and build tooling version
  * Modified release workflow to trigger only on tagged push events
  * Disabled automatic updater installer generation in releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->