### PR TITLE
docs: fix MDX/Mermaid build errors in v2 docs

### DIFF
--- a/docs/v2/advanced/stateful_cursor.mdx
+++ b/docs/v2/advanced/stateful_cursor.mdx
@@ -25,7 +25,8 @@ and resumes the source from there.
 Add a top-level `[cursor]` section to enable the feature, and pick a backend with `type`:
 
 <Tabs syncKey="cursor-backend">
-  <TabItem label="Memory">
+<TabItem label="Memory">
+
 Keeps the cursor in memory only — the position is **not** persisted across restarts. This is
 the default when no `[cursor]` section is present, and takes no extra fields.
 
@@ -33,8 +34,10 @@ the default when no `[cursor]` section is present, and takes no extra fields.
 [cursor]
 type = "Memory"
 ```
-  </TabItem>
-  <TabItem label="File">
+
+</TabItem>
+<TabItem label="File">
+
 Stores the cursor in a JSON file on the local file system.
 
 ```toml title="daemon.toml"
@@ -51,8 +54,10 @@ flush_interval = 10
   recover across rollbacks.
 - `flush_interval` (optional, default = `10`): how often, in seconds, the position is written
   to disk.
-  </TabItem>
-  <TabItem label="Redis">
+
+</TabItem>
+<TabItem label="Redis">
+
 Stores the cursor in a Redis instance — handy when running multiple environments or ephemeral
 containers.
 
@@ -70,5 +75,6 @@ flush_interval = 10
 - `max_breadcrumbs` (optional, default = `10`): how many recent positions to retain.
 - `flush_interval` (optional, default = `10`): how often, in seconds, the position is flushed
   to Redis.
-  </TabItem>
+
+</TabItem>
 </Tabs>

--- a/docs/v2/how_it_works.mdx
+++ b/docs/v2/how_it_works.mdx
@@ -11,11 +11,11 @@ batches.
 
 ```mermaid
 flowchart LR
-    node([Cardano node]) -->|Ouroboros mini-protocols| source[Source]
+    cnode([Cardano node]) -->|Ouroboros mini-protocols| source[Source]
     source --> f1[Filter] --> f2[Filter] --> sink[Sink]
     sink --> dest([Destination])
-    sink -.reports position.-> cursor[(Cursor)]
-    cursor -.restores on restart.-> source
+    sink -. reports position .-> cursor[(Cursor)]
+    cursor -. restores on restart .-> source
 ```
 
 ## The pipeline


### PR DESCRIPTION
## Problem

The Starlight docs build (`txpipe/docs`) fails compiling the v2 docset merged in #950:

```
[@mdx-js/rollup] Expected the closing tag `</TabItem>` either after the end of `listItem` …
file: …/oura-v2/docs/v2/advanced/stateful_cursor.mdx
```

## Cause & fix

- **`advanced/stateful_cursor.mdx`** — a `</TabItem>` indented two spaces sat directly after a Markdown list. A `- ` list's content-indent is two spaces, so the closing tag was absorbed as a *loose list-item paragraph* and MDX never saw it. Moving all `Tabs`/`TabItem` tags to **column 0** with blank lines around the content puts them outside the list. (The other `Tabs` pages — `binary_release`, `kubernetes` — only have fenced code blocks before their closing tags, which parse fine, so they're untouched.)
- **`how_it_works.mdx`** — hardened the new Mermaid block to canonical syntax (spaced `-. label .->` dotted links, non-reserved node id) so `rehype-mermaid`'s `img-svg` renderer accepts it.

## Verification

Ran a full local `astro build` of `txpipe/docs` against this content (deps + Chromium installed for the Mermaid render):

- **195 pages built, build Complete** — no MDX errors.
- The diagram rasterizes to an `data:image/svg+xml,…aria-roledescription='flowchart'` SVG (browser render succeeded).
- All three new pages (`how_it_works`, `quickstart`, `troubleshooting`) render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced formatting and spacing in stateful cursor configuration documentation and system flowchart diagrams for improved clarity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->